### PR TITLE
ci: main-tagged image for e2e

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,3 +46,36 @@ jobs:
         with:
           go-version: "1.26"
       - run: go test -race -count=1 ./pkg/controllers/...
+
+  image:
+    # Build + push a testable controller image for every commit on main, so
+    # downstream e2e (mono cluster-ops) can install a known tag without a release.
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=main
+            type=sha,prefix=main-,format=short
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
Builds `ghcr.io/paperclipinc/karpenter-provider-hetzner:main-<sha>` (and `:main`) on each main commit so the mono `karpenter-e2e` op can install a known image without cutting a release. Image job only runs on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)