### PR TITLE
fix(docker): cross-compile multi-arch (no QEMU)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,13 @@
-FROM golang:1.26-alpine AS builder
+# Cross-compile from the native build platform to the target platform so multi-arch
+# builds don't run `go build` under slow QEMU emulation.
+FROM --platform=$BUILDPLATFORM golang:1.26-alpine AS builder
+ARG TARGETOS
+ARG TARGETARCH
 WORKDIR /app
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN CGO_ENABLED=0 go build -o /karpenter-provider-hetzner ./cmd/controller
+RUN CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -o /karpenter-provider-hetzner ./cmd/controller
 
 FROM gcr.io/distroless/static-debian12:nonroot
 COPY --from=builder /karpenter-provider-hetzner /karpenter-provider-hetzner


### PR DESCRIPTION
The arm64 image leg ran `go build` under QEMU emulation (~20+ min). Build on `$BUILDPLATFORM` and cross-compile with `GOOS/GOARCH` so both CI and release image builds are fast. CGO is already disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)