### PR TITLE
fix(crd): HCloudNodeClass must be cluster-scoped

### DIFF
--- a/charts/karpenter-provider-hetzner/crds/karpenter.hetzner.cloud_hcloudnodeclasses.yaml
+++ b/charts/karpenter-provider-hetzner/crds/karpenter.hetzner.cloud_hcloudnodeclasses.yaml
@@ -16,7 +16,7 @@ spec:
     shortNames:
     - hcnc
     singular: hcloudnodeclass
-  scope: Namespaced
+  scope: Cluster
   versions:
   - additionalPrinterColumns:
     - jsonPath: .status.conditions[?(@.type=='Ready')].status

--- a/pkg/apis/v1alpha1/hcloudnodeclass_types.go
+++ b/pkg/apis/v1alpha1/hcloudnodeclass_types.go
@@ -14,7 +14,7 @@ const (
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:categories=karpenter,shortName=hcnc
+// +kubebuilder:resource:categories=karpenter,shortName=hcnc,scope=Cluster
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
 type HCloudNodeClass struct {
 	metav1.TypeMeta   `json:",inline"`


### PR DESCRIPTION
Karpenter NodeClasses are cluster-scoped; the cloudprovider Gets them with an empty namespace. The CRD was generated Namespaced, so Karpenter couldn't resolve a created NodeClass (NotFound) and never provisioned. Add scope=Cluster + regenerate. Surfaced by the mono e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)