### PR TITLE
fix: map 'unsupported location' create errors to unavailable

### DIFF
--- a/pkg/providers/instance/errors.go
+++ b/pkg/providers/instance/errors.go
@@ -1,15 +1,19 @@
 package instance
 
 import (
+	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	karpcp "sigs.k8s.io/karpenter/pkg/cloudprovider"
 )
 
 // MapCreateError converts a Hetzner create error into the appropriate Karpenter
-// error type. Capacity/quota errors become InsufficientCapacityError so the
-// scheduler tries another instance type or zone; nil passes through as nil.
+// error type. Errors that mean "this server type cannot be created in this
+// location right now" become InsufficientCapacityError so the scheduler marks
+// the offering unavailable and falls back to another type/zone instead of
+// retrying the same doomed combination. nil passes through as nil.
 func MapCreateError(err error) error {
 	if err == nil {
 		return nil
@@ -18,9 +22,28 @@ func MapCreateError(err error) error {
 	case hcloud.IsError(err, hcloud.ErrorCodeResourceUnavailable),
 		hcloud.IsError(err, hcloud.ErrorCodeResourceLimitExceeded):
 		return karpcp.NewInsufficientCapacityError(err)
+	case isUnsupportedPlacement(err):
+		// e.g. "unsupported location for server type" (invalid_input): the type
+		// is priced but not creatable in this location. Treat it as an
+		// unavailable offering so Karpenter routes around it.
+		return karpcp.NewInsufficientCapacityError(err)
 	default:
 		// Rate limits and transient errors stay as ordinary errors so Karpenter
 		// requeues and retries the same offering.
 		return fmt.Errorf("creating server: %w", err)
 	}
+}
+
+// isUnsupportedPlacement reports whether the error is Hetzner rejecting a
+// (server type, location) combination as not creatable. Hetzner returns this as
+// a generic invalid_input, so we match the placement-specific message rather
+// than treating every invalid_input as a capacity signal.
+func isUnsupportedPlacement(err error) bool {
+	var he hcloud.Error
+	if !errors.As(err, &he) || he.Code != hcloud.ErrorCodeInvalidInput {
+		return false
+	}
+	m := strings.ToLower(he.Message)
+	return strings.Contains(m, "unsupported location") ||
+		strings.Contains(m, "location for server type")
 }

--- a/pkg/providers/instance/errors_test.go
+++ b/pkg/providers/instance/errors_test.go
@@ -19,6 +19,8 @@ func TestMapCreateError(t *testing.T) {
 		{"unavailable", hcloud.Error{Code: hcloud.ErrorCodeResourceUnavailable}, true, false},
 		{"resource-limit", hcloud.Error{Code: hcloud.ErrorCodeResourceLimitExceeded}, true, false},
 		{"rate-limit", hcloud.Error{Code: hcloud.ErrorCodeRateLimitExceeded}, false, false},
+		{"unsupported-location", hcloud.Error{Code: hcloud.ErrorCodeInvalidInput, Message: "unsupported location for server type"}, true, false},
+		{"other-invalid-input", hcloud.Error{Code: hcloud.ErrorCodeInvalidInput, Message: "server name is invalid"}, false, false},
 		{"other", errors.New("boom"), false, false},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
A priced-but-not-creatable (type, location) returns invalid_input; previously Karpenter hot-looped on it forever. Map the placement message to InsufficientCapacityError so the offering is marked unavailable and the scheduler falls back. Surfaced by the mono e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)