### PR TITLE
chore: chart 0.3.0 (userDataSecretRef)

### DIFF
--- a/charts/karpenter-provider-hetzner/Chart.yaml
+++ b/charts/karpenter-provider-hetzner/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: karpenter-provider-hetzner
 description: Karpenter cloud provider for Hetzner Cloud
 type: application
-version: 0.2.0
-appVersion: "0.2.0"
+version: 0.3.0
+appVersion: "0.3.0"


### PR DESCRIPTION
Bump chart + appVersion to 0.3.0 for the userDataSecretRef release (#20).

Cutting `v0.3.0` after merge publishes the multi-arch image `ghcr.io/paperclipinc/karpenter-provider-hetzner:0.3.0` and the OCI chart `oci://ghcr.io/paperclipinc/charts/karpenter-provider-hetzner:0.3.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)