### PR TITLE
fix: P0 correctness — placement groups + location drift

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -39,7 +39,7 @@ func main() {
 	}
 
 	// Create the three providers.
-	instanceProvider := instance.NewProviderWithWaiter(&hcloudClient.Server, cfg.ClusterName, &hcloudClient.Action)
+	instanceProvider := instance.NewProviderWithPlacementGroups(&hcloudClient.Server, &hcloudClient.PlacementGroup, cfg.ClusterName, &hcloudClient.Action)
 	typeProvider := instancetype.NewProvider(&hcloudClient.ServerType)
 	imageProvider := imagefamily.NewProvider(&hcloudClient.Image)
 

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -30,6 +30,7 @@ const (
 	DriftNetwork    karpcp.DriftReason = "NetworkDrift"
 	DriftFirewall   karpcp.DriftReason = "FirewallDrift"
 	DriftServerType karpcp.DriftReason = "ServerTypeDrift"
+	DriftLocation   karpcp.DriftReason = "LocationDrift"
 )
 
 // CloudProvider implements the Karpenter CloudProvider interface for Hetzner Cloud.
@@ -311,6 +312,23 @@ func (cp *CloudProvider) IsDrifted(ctx context.Context, nodeClaim *karpv1.NodeCl
 	if want := nodeClaim.Labels[corev1.LabelInstanceTypeStable]; want != "" &&
 		server.ServerType != nil && server.ServerType.Name != want {
 		return DriftServerType, nil
+	}
+
+	// Location drift: the server's datacenter location must be in the NodeClass
+	// Locations list. Guards nil Datacenter/Location pointers defensively.
+	if len(nodeClass.Spec.Locations) > 0 &&
+		server.Datacenter != nil && server.Datacenter.Location != nil {
+		serverLocation := server.Datacenter.Location.Name
+		inAllowed := false
+		for _, loc := range nodeClass.Spec.Locations {
+			if loc == serverLocation {
+				inAllowed = true
+				break
+			}
+		}
+		if !inAllowed {
+			return DriftLocation, nil
+		}
 	}
 
 	// SSH-key and user-data drift are intentionally not checked: Hetzner does not

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -151,19 +151,20 @@ func (cp *CloudProvider) Create(ctx context.Context, nodeClaim *karpv1.NodeClaim
 
 	// Create the server.
 	server, err := cp.instanceProvider.Create(ctx, instance.CreateOpts{
-		Name:             nodeClaim.Name,
-		ServerType:       selected.Name,
-		Location:         location,
-		Image:            image,
-		NetworkID:        nodeClass.Spec.NetworkID,
-		FirewallIDs:      nodeClass.Spec.FirewallIDs,
-		SSHKeyIDs:        nodeClass.Spec.SSHKeyIDs,
-		Labels:           nodeClass.Spec.Labels,
-		UserData:         userData,
-		NodeClaim:        nodeClaim.Name,
-		NodePool:         nodePoolName,
-		EnablePublicIPv4: nodeClass.Spec.PublicIPv4Enabled(),
-		EnablePublicIPv6: nodeClass.Spec.PublicIPv6Enabled(),
+		Name:                   nodeClaim.Name,
+		ServerType:             selected.Name,
+		Location:               location,
+		Image:                  image,
+		NetworkID:              nodeClass.Spec.NetworkID,
+		FirewallIDs:            nodeClass.Spec.FirewallIDs,
+		SSHKeyIDs:              nodeClass.Spec.SSHKeyIDs,
+		Labels:                 nodeClass.Spec.Labels,
+		UserData:               userData,
+		NodeClaim:              nodeClaim.Name,
+		NodePool:               nodePoolName,
+		PlacementGroupStrategy: nodeClass.Spec.PlacementGroupStrategy,
+		EnablePublicIPv4:       nodeClass.Spec.PublicIPv4Enabled(),
+		EnablePublicIPv6:       nodeClass.Spec.PublicIPv6Enabled(),
 	})
 	if err != nil {
 		if karpcp.IsInsufficientCapacityError(err) {

--- a/pkg/cloudprovider/cloudprovider_test.go
+++ b/pkg/cloudprovider/cloudprovider_test.go
@@ -550,3 +550,93 @@ func TestCreate_UserDataSecretMissing(t *testing.T) {
 		t.Fatal("expected error when userDataSecretRef points to a missing Secret, got nil")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// DriftNetwork test (the detection code exists but was untested)
+// ---------------------------------------------------------------------------
+
+// TestIsDrifted_Network verifies that a server not attached to the NodeClass
+// network is flagged as DriftNetwork.
+func TestIsDrifted_Network(t *testing.T) {
+	nc := baselineNodeClass() // expects NetworkID=1
+	server := baselineServer()
+	// Replace the attached network with a different ID.
+	server.PrivateNet = []hcloud.ServerPrivateNet{{Network: &hcloud.Network{ID: 99}}}
+	cp, nodeClaim := buildCP(t, nc, server)
+	reason, err := cp.IsDrifted(context.Background(), nodeClaim)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reason != cloudprovider.DriftNetwork {
+		t.Errorf("want DriftNetwork, got %q", reason)
+	}
+}
+
+// TestIsDrifted_NetworkAttached_NoDrift verifies that a server correctly
+// attached to the NodeClass network is not flagged as drifted.
+func TestIsDrifted_NetworkAttached_NoDrift(t *testing.T) {
+	nc := baselineNodeClass() // expects NetworkID=1
+	server := baselineServer()
+	server.PrivateNet = []hcloud.ServerPrivateNet{{Network: &hcloud.Network{ID: 1}}}
+	cp, nodeClaim := buildCP(t, nc, server)
+	reason, err := cp.IsDrifted(context.Background(), nodeClaim)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reason != "" {
+		t.Errorf("expected no drift when network correctly attached, got %q", reason)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Location drift tests
+// ---------------------------------------------------------------------------
+
+// TestIsDrifted_Location verifies that a server whose datacenter location is
+// not in the NodeClass Locations list is flagged as DriftLocation.
+func TestIsDrifted_Location(t *testing.T) {
+	nc := baselineNodeClass() // Locations: ["nbg1"]
+	server := baselineServer()
+	// Server is in "hel1" which is not in the NodeClass locations.
+	server.Datacenter = &hcloud.Datacenter{Location: &hcloud.Location{Name: "hel1"}}
+	cp, nodeClaim := buildCP(t, nc, server)
+	reason, err := cp.IsDrifted(context.Background(), nodeClaim)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reason != cloudprovider.DriftLocation {
+		t.Errorf("want DriftLocation, got %q", reason)
+	}
+}
+
+// TestIsDrifted_LocationInList_NoDrift verifies that a server in a location
+// that is present in the NodeClass Locations list is not flagged as drifted.
+func TestIsDrifted_LocationInList_NoDrift(t *testing.T) {
+	nc := baselineNodeClass() // Locations: ["nbg1"]
+	server := baselineServer()
+	server.Datacenter = &hcloud.Datacenter{Location: &hcloud.Location{Name: "nbg1"}}
+	cp, nodeClaim := buildCP(t, nc, server)
+	reason, err := cp.IsDrifted(context.Background(), nodeClaim)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reason != "" {
+		t.Errorf("expected no drift when location is in list, got %q", reason)
+	}
+}
+
+// TestIsDrifted_Location_NilDatacenter_NoDrift verifies that a server with a
+// nil Datacenter (e.g. mid-provisioning) does not report location drift.
+func TestIsDrifted_Location_NilDatacenter_NoDrift(t *testing.T) {
+	nc := baselineNodeClass()
+	server := baselineServer()
+	server.Datacenter = nil // nil datacenter -> guard should skip the check
+	cp, nodeClaim := buildCP(t, nc, server)
+	reason, err := cp.IsDrifted(context.Background(), nodeClaim)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reason != "" {
+		t.Errorf("expected no drift for nil Datacenter, got %q", reason)
+	}
+}

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -39,21 +39,22 @@ type Provider struct {
 }
 
 // NewProvider returns a Provider that does NOT wait for hcloud actions to
-// complete after server creation. Use it only in tests that do not exercise
-// action waiting; production code should use NewProviderWithWaiter.
+// complete after server creation and has no placement-group support. Intended
+// for tests; production uses NewProviderWithPlacementGroups.
 func NewProvider(client ServerClient, clusterName string) *Provider {
 	return &Provider{client: client, clusterName: clusterName}
 }
 
 // NewProviderWithWaiter returns a Provider that blocks after server creation
-// until all hcloud create actions complete. Use this in production.
+// until all hcloud create actions complete, but has no placement-group support.
+// Intended for tests; production uses NewProviderWithPlacementGroups.
 func NewProviderWithWaiter(client ServerClient, clusterName string, waiter ActionWaiter) *Provider {
 	return &Provider{client: client, waiter: waiter, clusterName: clusterName}
 }
 
 // NewProviderWithPlacementGroups returns a Provider that supports placement
-// groups and waits for hcloud create actions to complete. Use this in
-// production when PlacementGroupStrategy is needed.
+// groups and waits for hcloud create actions to complete. This is the
+// production constructor.
 func NewProviderWithPlacementGroups(client ServerClient, pgClient PlacementGroupClient, clusterName string, waiter ActionWaiter) *Provider {
 	return &Provider{client: client, pgClient: pgClient, waiter: waiter, clusterName: clusterName}
 }
@@ -76,19 +77,24 @@ type CreateOpts struct {
 	EnablePublicIPv6       bool
 }
 
-// placementGroupName returns the deterministic placement group name for a node pool.
-// When nodePool is empty it falls back to "karpenter".
-func placementGroupName(nodePool string) string {
+// placementGroupName returns the deterministic placement group name for a node
+// pool, scoped to the cluster so two clusters sharing a Hetzner project (and a
+// node-pool name) do not collide on the same placement group. When nodePool is
+// empty it falls back to the cluster-scoped default.
+func placementGroupName(clusterName, nodePool string) string {
+	base := "karpenter-" + clusterName
 	if nodePool == "" {
-		return "karpenter"
+		return base
 	}
-	return "karpenter-" + nodePool
+	return base + "-" + nodePool
 }
 
 // getOrCreatePlacementGroup finds an existing placement group of type spread
 // with the given name, creating it if it does not exist yet. It returns the
 // group's ID, or 0 and an error on failure.
 func (p *Provider) getOrCreatePlacementGroup(ctx context.Context, name string) (int64, error) {
+	// AllWithOpts filters server-side by Name + Type, so a non-empty result is
+	// already the group we want.
 	existing, err := p.pgClient.AllWithOpts(ctx, hcloud.PlacementGroupListOpts{
 		Name: name,
 		Type: hcloud.PlacementGroupTypeSpread,
@@ -96,10 +102,8 @@ func (p *Provider) getOrCreatePlacementGroup(ctx context.Context, name string) (
 	if err != nil {
 		return 0, fmt.Errorf("listing placement groups: %w", err)
 	}
-	for _, pg := range existing {
-		if pg.Name == name {
-			return pg.ID, nil
-		}
+	if len(existing) > 0 {
+		return existing[0].ID, nil
 	}
 
 	result, _, err := p.pgClient.Create(ctx, hcloud.PlacementGroupCreateOpts{
@@ -167,7 +171,7 @@ func (p *Provider) Create(ctx context.Context, opts CreateOpts) (*hcloud.Server,
 	// Apply placement group when strategy is "spread" (or empty, since spread
 	// is the kubebuilder default). Strategy "none" intentionally skips this.
 	if p.pgClient != nil && opts.PlacementGroupStrategy != "none" {
-		pgName := placementGroupName(opts.NodePool)
+		pgName := placementGroupName(p.clusterName, opts.NodePool)
 		pgID, err := p.getOrCreatePlacementGroup(ctx, pgName)
 		if err != nil {
 			return nil, fmt.Errorf("resolving placement group: %w", err)

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -19,6 +19,12 @@ type ServerClient interface {
 	AllWithOpts(ctx context.Context, opts hcloud.ServerListOpts) ([]*hcloud.Server, error)
 }
 
+// PlacementGroupClient is the narrow interface for the hcloud placement groups API.
+type PlacementGroupClient interface {
+	AllWithOpts(ctx context.Context, opts hcloud.PlacementGroupListOpts) ([]*hcloud.PlacementGroup, error)
+	Create(ctx context.Context, opts hcloud.PlacementGroupCreateOpts) (hcloud.PlacementGroupCreateResult, *hcloud.Response, error)
+}
+
 // ActionWaiter waits for hcloud actions to complete. *hcloud.ActionClient satisfies it.
 type ActionWaiter interface {
 	WaitFor(ctx context.Context, actions ...*hcloud.Action) error
@@ -26,9 +32,10 @@ type ActionWaiter interface {
 
 // Provider wraps hcloud server CRUD operations for Karpenter.
 type Provider struct {
-	client      ServerClient
-	waiter      ActionWaiter
-	clusterName string
+	client         ServerClient
+	pgClient       PlacementGroupClient
+	waiter         ActionWaiter
+	clusterName    string
 }
 
 // NewProvider returns a Provider that does NOT wait for hcloud actions to
@@ -44,21 +51,65 @@ func NewProviderWithWaiter(client ServerClient, clusterName string, waiter Actio
 	return &Provider{client: client, waiter: waiter, clusterName: clusterName}
 }
 
+// NewProviderWithPlacementGroups returns a Provider that supports placement
+// groups and waits for hcloud create actions to complete. Use this in
+// production when PlacementGroupStrategy is needed.
+func NewProviderWithPlacementGroups(client ServerClient, pgClient PlacementGroupClient, clusterName string, waiter ActionWaiter) *Provider {
+	return &Provider{client: client, pgClient: pgClient, waiter: waiter, clusterName: clusterName}
+}
+
 // CreateOpts contains all parameters needed to create a Hetzner server node.
 type CreateOpts struct {
-	Name             string
-	ServerType       string
-	Location         string
-	Image            *hcloud.Image
-	NetworkID        int64
-	FirewallIDs      []int64
-	SSHKeyIDs        []int64
-	Labels           map[string]string
-	UserData         string
-	NodeClaim        string
-	NodePool         string
-	EnablePublicIPv4 bool
-	EnablePublicIPv6 bool
+	Name                   string
+	ServerType             string
+	Location               string
+	Image                  *hcloud.Image
+	NetworkID              int64
+	FirewallIDs            []int64
+	SSHKeyIDs              []int64
+	Labels                 map[string]string
+	UserData               string
+	NodeClaim              string
+	NodePool               string
+	PlacementGroupStrategy string
+	EnablePublicIPv4       bool
+	EnablePublicIPv6       bool
+}
+
+// placementGroupName returns the deterministic placement group name for a node pool.
+// When nodePool is empty it falls back to "karpenter".
+func placementGroupName(nodePool string) string {
+	if nodePool == "" {
+		return "karpenter"
+	}
+	return "karpenter-" + nodePool
+}
+
+// getOrCreatePlacementGroup finds an existing placement group of type spread
+// with the given name, creating it if it does not exist yet. It returns the
+// group's ID, or 0 and an error on failure.
+func (p *Provider) getOrCreatePlacementGroup(ctx context.Context, name string) (int64, error) {
+	existing, err := p.pgClient.AllWithOpts(ctx, hcloud.PlacementGroupListOpts{
+		Name: name,
+		Type: hcloud.PlacementGroupTypeSpread,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("listing placement groups: %w", err)
+	}
+	for _, pg := range existing {
+		if pg.Name == name {
+			return pg.ID, nil
+		}
+	}
+
+	result, _, err := p.pgClient.Create(ctx, hcloud.PlacementGroupCreateOpts{
+		Name: name,
+		Type: hcloud.PlacementGroupTypeSpread,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("creating placement group %q: %w", name, err)
+	}
+	return result.PlacementGroup.ID, nil
 }
 
 // Create provisions a new Hetzner server, merging Karpenter management labels.
@@ -111,6 +162,17 @@ func (p *Provider) Create(ctx context.Context, opts CreateOpts) (*hcloud.Server,
 	createOpts.PublicNet = &hcloud.ServerCreatePublicNet{
 		EnableIPv4: opts.EnablePublicIPv4,
 		EnableIPv6: opts.EnablePublicIPv6,
+	}
+
+	// Apply placement group when strategy is "spread" (or empty, since spread
+	// is the kubebuilder default). Strategy "none" intentionally skips this.
+	if p.pgClient != nil && opts.PlacementGroupStrategy != "none" {
+		pgName := placementGroupName(opts.NodePool)
+		pgID, err := p.getOrCreatePlacementGroup(ctx, pgName)
+		if err != nil {
+			return nil, fmt.Errorf("resolving placement group: %w", err)
+		}
+		createOpts.PlacementGroup = &hcloud.PlacementGroup{ID: pgID}
 	}
 
 	result, _, err := p.client.Create(ctx, createOpts)

--- a/pkg/providers/instance/instance_test.go
+++ b/pkg/providers/instance/instance_test.go
@@ -340,3 +340,188 @@ func TestCreate_WaitsForNextActions(t *testing.T) {
 		t.Errorf("expected 2 next-actions waited, got %d", waiter.waited)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// mockPlacementGroupClient and placement group tests
+// ---------------------------------------------------------------------------
+
+type mockPlacementGroupClient struct {
+	groups    []*hcloud.PlacementGroup
+	nextID    int64
+	createErr error
+	// recorded arguments for assertions
+	lastListOpts   hcloud.PlacementGroupListOpts
+	lastCreateOpts hcloud.PlacementGroupCreateOpts
+	createCalls    int
+}
+
+func newMockPlacementGroupClient() *mockPlacementGroupClient {
+	return &mockPlacementGroupClient{nextID: 200}
+}
+
+func (m *mockPlacementGroupClient) AllWithOpts(_ context.Context, opts hcloud.PlacementGroupListOpts) ([]*hcloud.PlacementGroup, error) {
+	m.lastListOpts = opts
+	var result []*hcloud.PlacementGroup
+	for _, pg := range m.groups {
+		if opts.Name != "" && pg.Name != opts.Name {
+			continue
+		}
+		if opts.Type != "" && pg.Type != opts.Type {
+			continue
+		}
+		result = append(result, pg)
+	}
+	return result, nil
+}
+
+func (m *mockPlacementGroupClient) Create(_ context.Context, opts hcloud.PlacementGroupCreateOpts) (hcloud.PlacementGroupCreateResult, *hcloud.Response, error) {
+	m.lastCreateOpts = opts
+	m.createCalls++
+	if m.createErr != nil {
+		return hcloud.PlacementGroupCreateResult{}, nil, m.createErr
+	}
+	id := m.nextID
+	m.nextID++
+	pg := &hcloud.PlacementGroup{ID: id, Name: opts.Name, Type: opts.Type}
+	m.groups = append(m.groups, pg)
+	return hcloud.PlacementGroupCreateResult{PlacementGroup: pg}, nil, nil
+}
+
+// TestCreate_SpreadStrategy_CreatesPG verifies that strategy "spread" (default)
+// causes a placement group to be created and assigned to the server.
+func TestCreate_SpreadStrategy_CreatesPG(t *testing.T) {
+	sc := newMockServerClient()
+	pgc := newMockPlacementGroupClient()
+	p := NewProviderWithPlacementGroups(sc, pgc, "test-cluster", nil)
+
+	_, err := p.Create(context.Background(), CreateOpts{
+		Name:                   "n",
+		ServerType:             "cx22",
+		Location:               "nbg1",
+		Image:                  &hcloud.Image{ID: 1},
+		NodePool:               "my-pool",
+		PlacementGroupStrategy: "spread",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// A placement group should have been created.
+	if pgc.createCalls != 1 {
+		t.Errorf("expected 1 PG create call, got %d", pgc.createCalls)
+	}
+	if pgc.lastCreateOpts.Name != "karpenter-my-pool" {
+		t.Errorf("expected PG name %q, got %q", "karpenter-my-pool", pgc.lastCreateOpts.Name)
+	}
+	if pgc.lastCreateOpts.Type != hcloud.PlacementGroupTypeSpread {
+		t.Errorf("expected spread type, got %q", pgc.lastCreateOpts.Type)
+	}
+	// The server create opts must include the placement group.
+	if sc.lastOpts.PlacementGroup == nil {
+		t.Error("expected PlacementGroup to be set on server create opts")
+	}
+}
+
+// TestCreate_SpreadStrategy_EmptyStrategy_CreatesPG verifies that an empty
+// strategy (the kubebuilder default "spread") also creates a placement group.
+func TestCreate_SpreadStrategy_EmptyStrategy_CreatesPG(t *testing.T) {
+	sc := newMockServerClient()
+	pgc := newMockPlacementGroupClient()
+	p := NewProviderWithPlacementGroups(sc, pgc, "test-cluster", nil)
+
+	_, err := p.Create(context.Background(), CreateOpts{
+		Name:       "n",
+		ServerType: "cx22",
+		Location:   "nbg1",
+		Image:      &hcloud.Image{ID: 1},
+		NodePool:   "pool-a",
+		// PlacementGroupStrategy intentionally left empty -> treated as spread
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sc.lastOpts.PlacementGroup == nil {
+		t.Error("expected PlacementGroup to be set on server create opts when strategy is empty")
+	}
+}
+
+// TestCreate_NoneStrategy_NoPG verifies that strategy "none" does NOT create or
+// assign a placement group.
+func TestCreate_NoneStrategy_NoPG(t *testing.T) {
+	sc := newMockServerClient()
+	pgc := newMockPlacementGroupClient()
+	p := NewProviderWithPlacementGroups(sc, pgc, "test-cluster", nil)
+
+	_, err := p.Create(context.Background(), CreateOpts{
+		Name:                   "n",
+		ServerType:             "cx22",
+		Location:               "nbg1",
+		Image:                  &hcloud.Image{ID: 1},
+		NodePool:               "my-pool",
+		PlacementGroupStrategy: "none",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pgc.createCalls != 0 {
+		t.Errorf("expected 0 PG create calls for strategy=none, got %d", pgc.createCalls)
+	}
+	if sc.lastOpts.PlacementGroup != nil {
+		t.Error("expected no PlacementGroup on server create opts when strategy=none")
+	}
+}
+
+// TestCreate_SpreadStrategy_ReusesPG verifies that when a placement group with
+// the expected name already exists, Create reuses it without calling create.
+func TestCreate_SpreadStrategy_ReusesPG(t *testing.T) {
+	sc := newMockServerClient()
+	pgc := newMockPlacementGroupClient()
+	// Pre-seed an existing placement group with the expected name.
+	existingID := int64(999)
+	pgc.groups = []*hcloud.PlacementGroup{
+		{ID: existingID, Name: "karpenter-my-pool", Type: hcloud.PlacementGroupTypeSpread},
+	}
+	p := NewProviderWithPlacementGroups(sc, pgc, "test-cluster", nil)
+
+	_, err := p.Create(context.Background(), CreateOpts{
+		Name:                   "n",
+		ServerType:             "cx22",
+		Location:               "nbg1",
+		Image:                  &hcloud.Image{ID: 1},
+		NodePool:               "my-pool",
+		PlacementGroupStrategy: "spread",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Should NOT have called create.
+	if pgc.createCalls != 0 {
+		t.Errorf("expected 0 PG create calls (reuse), got %d", pgc.createCalls)
+	}
+	// Should use the existing PG's ID.
+	if sc.lastOpts.PlacementGroup == nil || sc.lastOpts.PlacementGroup.ID != existingID {
+		t.Errorf("expected existing PG ID %d, got %v", existingID, sc.lastOpts.PlacementGroup)
+	}
+}
+
+// TestCreate_SpreadStrategy_EmptyNodePool verifies the fallback PG name when
+// NodePool is empty.
+func TestCreate_SpreadStrategy_EmptyNodePool(t *testing.T) {
+	sc := newMockServerClient()
+	pgc := newMockPlacementGroupClient()
+	p := NewProviderWithPlacementGroups(sc, pgc, "test-cluster", nil)
+
+	_, err := p.Create(context.Background(), CreateOpts{
+		Name:                   "n",
+		ServerType:             "cx22",
+		Location:               "nbg1",
+		Image:                  &hcloud.Image{ID: 1},
+		NodePool:               "", // empty
+		PlacementGroupStrategy: "spread",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if pgc.lastCreateOpts.Name != "karpenter" {
+		t.Errorf("expected PG name %q for empty NodePool, got %q", "karpenter", pgc.lastCreateOpts.Name)
+	}
+}

--- a/pkg/providers/instance/instance_test.go
+++ b/pkg/providers/instance/instance_test.go
@@ -409,8 +409,8 @@ func TestCreate_SpreadStrategy_CreatesPG(t *testing.T) {
 	if pgc.createCalls != 1 {
 		t.Errorf("expected 1 PG create call, got %d", pgc.createCalls)
 	}
-	if pgc.lastCreateOpts.Name != "karpenter-my-pool" {
-		t.Errorf("expected PG name %q, got %q", "karpenter-my-pool", pgc.lastCreateOpts.Name)
+	if pgc.lastCreateOpts.Name != "karpenter-test-cluster-my-pool" {
+		t.Errorf("expected PG name %q, got %q", "karpenter-test-cluster-my-pool", pgc.lastCreateOpts.Name)
 	}
 	if pgc.lastCreateOpts.Type != hcloud.PlacementGroupTypeSpread {
 		t.Errorf("expected spread type, got %q", pgc.lastCreateOpts.Type)
@@ -478,7 +478,7 @@ func TestCreate_SpreadStrategy_ReusesPG(t *testing.T) {
 	// Pre-seed an existing placement group with the expected name.
 	existingID := int64(999)
 	pgc.groups = []*hcloud.PlacementGroup{
-		{ID: existingID, Name: "karpenter-my-pool", Type: hcloud.PlacementGroupTypeSpread},
+		{ID: existingID, Name: "karpenter-test-cluster-my-pool", Type: hcloud.PlacementGroupTypeSpread},
 	}
 	p := NewProviderWithPlacementGroups(sc, pgc, "test-cluster", nil)
 
@@ -521,7 +521,7 @@ func TestCreate_SpreadStrategy_EmptyNodePool(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if pgc.lastCreateOpts.Name != "karpenter" {
-		t.Errorf("expected PG name %q for empty NodePool, got %q", "karpenter", pgc.lastCreateOpts.Name)
+	if pgc.lastCreateOpts.Name != "karpenter-test-cluster" {
+		t.Errorf("expected PG name %q for empty NodePool, got %q", "karpenter-test-cluster", pgc.lastCreateOpts.Name)
 	}
 }


### PR DESCRIPTION
Two P0 correctness fixes toward v1.0.0.

## A1: `placementGroupStrategy` was a silent no-op
The field was declared, defaulted `spread`, and documented, but `instance.Create()` never created or assigned a placement group. Now: for `spread` (or empty/default) it get-or-creates a `spread` placement group named `karpenter-<cluster>-<nodepool>` (cluster-scoped so two clusters sharing a Hetzner project don't collide) and assigns it; `none` assigns none. Wired with the real `hcloud.Client.PlacementGroup` in the controller. New constructor `NewProviderWithPlacementGroups`; existing ones preserved.

## A2: location drift (+ DriftNetwork test)
`IsDrifted` now flags `LocationDrift` when a server's datacenter location is no longer in the NodeClass `locations` (nil-guarded). Also adds the previously-missing `DriftNetwork` unit test.

## Tests
New unit tests: PG spread-creates / empty-creates / none-skips / reuse-existing / empty-nodepool; location drift + no-drift + nil-datacenter; network drift + no-drift. `go test ./...` and `go vet ./...` green.

Validation: will run the mono `karpenter-e2e` op (happy + drift scenarios) after merge to confirm placement groups attach and drift still triggers on the live cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)