### PR TITLE
fix(lint): green main — SA1019 server.Location, QF1008 test access, regen CRD

### DIFF
--- a/charts/karpenter-provider-hetzner/crds/karpenter.hetzner.cloud_hcloudnodeclasses.yaml
+++ b/charts/karpenter-provider-hetzner/crds/karpenter.hetzner.cloud_hcloudnodeclasses.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.21.0
+    controller-gen.kubebuilder.io/version: v0.19.0
   name: hcloudnodeclasses.karpenter.hetzner.cloud
 spec:
   group: karpenter.hetzner.cloud

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -314,11 +314,10 @@ func (cp *CloudProvider) IsDrifted(ctx context.Context, nodeClaim *karpv1.NodeCl
 		return DriftServerType, nil
 	}
 
-	// Location drift: the server's datacenter location must be in the NodeClass
-	// Locations list. Guards nil Datacenter/Location pointers defensively.
-	if len(nodeClass.Spec.Locations) > 0 &&
-		server.Datacenter != nil && server.Datacenter.Location != nil {
-		serverLocation := server.Datacenter.Location.Name
+	// Location drift: the server's location must be in the NodeClass Locations
+	// list. Guards a nil Location pointer defensively (e.g. mid-provisioning).
+	if len(nodeClass.Spec.Locations) > 0 && server.Location != nil {
+		serverLocation := server.Location.Name
 		inAllowed := false
 		for _, loc := range nodeClass.Spec.Locations {
 			if loc == serverLocation {

--- a/pkg/cloudprovider/cloudprovider_test.go
+++ b/pkg/cloudprovider/cloudprovider_test.go
@@ -598,7 +598,7 @@ func TestIsDrifted_Location(t *testing.T) {
 	nc := baselineNodeClass() // Locations: ["nbg1"]
 	server := baselineServer()
 	// Server is in "hel1" which is not in the NodeClass locations.
-	server.Datacenter = &hcloud.Datacenter{Location: &hcloud.Location{Name: "hel1"}}
+	server.Location = &hcloud.Location{Name: "hel1"}
 	cp, nodeClaim := buildCP(t, nc, server)
 	reason, err := cp.IsDrifted(context.Background(), nodeClaim)
 	if err != nil {
@@ -614,7 +614,7 @@ func TestIsDrifted_Location(t *testing.T) {
 func TestIsDrifted_LocationInList_NoDrift(t *testing.T) {
 	nc := baselineNodeClass() // Locations: ["nbg1"]
 	server := baselineServer()
-	server.Datacenter = &hcloud.Datacenter{Location: &hcloud.Location{Name: "nbg1"}}
+	server.Location = &hcloud.Location{Name: "nbg1"}
 	cp, nodeClaim := buildCP(t, nc, server)
 	reason, err := cp.IsDrifted(context.Background(), nodeClaim)
 	if err != nil {
@@ -625,18 +625,18 @@ func TestIsDrifted_LocationInList_NoDrift(t *testing.T) {
 	}
 }
 
-// TestIsDrifted_Location_NilDatacenter_NoDrift verifies that a server with a
-// nil Datacenter (e.g. mid-provisioning) does not report location drift.
-func TestIsDrifted_Location_NilDatacenter_NoDrift(t *testing.T) {
+// TestIsDrifted_Location_NilLocation_NoDrift verifies that a server with a nil
+// Location (e.g. mid-provisioning) does not report location drift.
+func TestIsDrifted_Location_NilLocation_NoDrift(t *testing.T) {
 	nc := baselineNodeClass()
 	server := baselineServer()
-	server.Datacenter = nil // nil datacenter -> guard should skip the check
+	server.Location = nil // nil location -> guard should skip the check
 	cp, nodeClaim := buildCP(t, nc, server)
 	reason, err := cp.IsDrifted(context.Background(), nodeClaim)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if reason != "" {
-		t.Errorf("expected no drift for nil Datacenter, got %q", reason)
+		t.Errorf("expected no drift for nil Location, got %q", reason)
 	}
 }

--- a/pkg/providers/imagefamily/imagefamily_test.go
+++ b/pkg/providers/imagefamily/imagefamily_test.go
@@ -192,7 +192,7 @@ func TestResolveTalos_LabelSelectorForwarded(t *testing.T) {
 	if _, err := p.Resolve(context.Background(), sel, hcloud.ArchitectureX86); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if got := fc.lastOpts.ListOpts.LabelSelector; got != "caph-image-name=talos-v1.13.3-gvisor" {
+	if got := fc.lastOpts.LabelSelector; got != "caph-image-name=talos-v1.13.3-gvisor" {
 		t.Fatalf("label selector not forwarded: got %q", got)
 	}
 }
@@ -206,7 +206,7 @@ func TestResolveUbuntu_LabelSelectorForwarded(t *testing.T) {
 	if _, err := p.Resolve(context.Background(), sel, hcloud.ArchitectureX86); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if got := fc.lastOpts.ListOpts.LabelSelector; got != "role=worker" {
+	if got := fc.lastOpts.LabelSelector; got != "role=worker" {
 		t.Fatalf("label selector not forwarded: got %q", got)
 	}
 }


### PR DESCRIPTION
Main went red after #23/#24 merged before their CI finished. This greens it.

- **SA1019**: `IsDrifted` location check now uses `server.Location` instead of the deprecated `server.Datacenter` (removed by Hetzner after 2026-07-01).
- **QF1008**: the label-selector forwarding tests use the promoted `fc.lastOpts.LabelSelector` accessor. (The production struct literal keeps the explicit `ListOpts{...}` — Go requires it for a promoted field in a composite literal.)
- **generate-verify**: regenerated deepcopy + CRD with the CI-pinned `controller-gen@v0.19.0`.

`go build`, `go test`, `staticcheck`, and `make generate-verify` all clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)