### PR TITLE
feat: hardening — seccomp, structured logging, label drift

### DIFF
--- a/charts/karpenter-provider-hetzner/templates/deployment.yaml
+++ b/charts/karpenter-provider-hetzner/templates/deployment.yaml
@@ -21,6 +21,9 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       serviceAccountName: {{ .Values.serviceAccount.name }}
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       containers:
         - name: controller
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -32,6 +32,7 @@ const (
 	DriftFirewall   karpcp.DriftReason = "FirewallDrift"
 	DriftServerType karpcp.DriftReason = "ServerTypeDrift"
 	DriftLocation   karpcp.DriftReason = "LocationDrift"
+	DriftLabels     karpcp.DriftReason = "LabelsDrift"
 )
 
 // CloudProvider implements the Karpenter CloudProvider interface for Hetzner Cloud.
@@ -338,6 +339,18 @@ func (cp *CloudProvider) IsDrifted(ctx context.Context, nodeClaim *karpv1.NodeCl
 		}
 		if !inAllowed {
 			return logDrift(DriftLocation, nodeClaim.Status.ProviderID), nil
+		}
+	}
+
+	// Label drift: every key/value in NodeClass spec.labels must be present and
+	// matching on the server. Extra labels on the server (karpenter management,
+	// offering labels, etc.) are permitted and do not count as drift. Empty/nil
+	// spec labels means nothing is required — skip the check.
+	if len(nodeClass.Spec.Labels) > 0 {
+		for k, want := range nodeClass.Spec.Labels {
+			if got, ok := server.Labels[k]; !ok || got != want {
+				return logDrift(DriftLabels, nodeClaim.Status.ProviderID), nil
+			}
 		}
 	}
 

--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 	karpcp "sigs.k8s.io/karpenter/pkg/cloudprovider"
 	"sigs.k8s.io/karpenter/pkg/scheduling"
@@ -84,6 +85,7 @@ func (cp *CloudProvider) RepairPolicies() []karpcp.RepairPolicy {
 
 // Create provisions a new Hetzner server for the given NodeClaim.
 func (cp *CloudProvider) Create(ctx context.Context, nodeClaim *karpv1.NodeClaim) (*karpv1.NodeClaim, error) {
+	log := logf.FromContext(ctx)
 	nodeClass, err := cp.resolveNodeClass(ctx, nodeClaim.Spec.NodeClassRef)
 	if err != nil {
 		return nil, fmt.Errorf("resolving node class: %w", err)
@@ -118,6 +120,7 @@ func (cp *CloudProvider) Create(ctx context.Context, nodeClaim *karpv1.NodeClaim
 	if arch == "arm64" {
 		hcloudArch = hcloud.ArchitectureARM
 	}
+	log.Info("selected instance type", "instanceType", selected.Name, "arch", arch)
 
 	// Resolve OS image.
 	image, err := cp.imageProvider.Resolve(ctx, nodeClass.Spec.ImageSelector, hcloudArch)
@@ -251,6 +254,7 @@ func (cp *CloudProvider) GetInstanceTypes(ctx context.Context, nodePool *karpv1.
 
 // IsDrifted determines whether the given NodeClaim has drifted from its desired state.
 func (cp *CloudProvider) IsDrifted(ctx context.Context, nodeClaim *karpv1.NodeClaim) (karpcp.DriftReason, error) {
+	log := logf.FromContext(ctx)
 	nodeClass, err := cp.resolveNodeClass(ctx, nodeClaim.Spec.NodeClassRef)
 	if err != nil {
 		return "", fmt.Errorf("resolving node class: %w", err)
@@ -264,12 +268,19 @@ func (cp *CloudProvider) IsDrifted(ctx context.Context, nodeClaim *karpv1.NodeCl
 		return "", nil
 	}
 
+	// logDrift emits a structured INFO log and returns the reason so callers can
+	// write: return logDrift(log, reason, providerID), nil
+	logDrift := func(reason karpcp.DriftReason, providerID string) karpcp.DriftReason {
+		log.Info("drift detected", "reason", string(reason), "providerID", providerID)
+		return reason
+	}
+
 	// Check image drift: compare the resolved image ID recorded in NodeClaim status against
 	// the current server image.
 	if nodeClaim.Status.ImageID != "" && server.Image != nil {
 		currentImageID := strconv.FormatInt(server.Image.ID, 10)
 		if nodeClaim.Status.ImageID != currentImageID {
-			return DriftImage, nil
+			return logDrift(DriftImage, nodeClaim.Status.ProviderID), nil
 		}
 	}
 
@@ -283,7 +294,7 @@ func (cp *CloudProvider) IsDrifted(ctx context.Context, nodeClaim *karpv1.NodeCl
 			}
 		}
 		if !attached {
-			return DriftNetwork, nil
+			return logDrift(DriftNetwork, nodeClaim.Status.ProviderID), nil
 		}
 	}
 
@@ -300,7 +311,7 @@ func (cp *CloudProvider) IsDrifted(ctx context.Context, nodeClaim *karpv1.NodeCl
 		}
 		for _, want := range nodeClass.Spec.FirewallIDs {
 			if !attached[want] {
-				return DriftFirewall, nil
+				return logDrift(DriftFirewall, nodeClaim.Status.ProviderID), nil
 			}
 		}
 	}
@@ -311,7 +322,7 @@ func (cp *CloudProvider) IsDrifted(ctx context.Context, nodeClaim *karpv1.NodeCl
 	// reporting false drift.
 	if want := nodeClaim.Labels[corev1.LabelInstanceTypeStable]; want != "" &&
 		server.ServerType != nil && server.ServerType.Name != want {
-		return DriftServerType, nil
+		return logDrift(DriftServerType, nodeClaim.Status.ProviderID), nil
 	}
 
 	// Location drift: the server's location must be in the NodeClass Locations
@@ -326,7 +337,7 @@ func (cp *CloudProvider) IsDrifted(ctx context.Context, nodeClaim *karpv1.NodeCl
 			}
 		}
 		if !inAllowed {
-			return DriftLocation, nil
+			return logDrift(DriftLocation, nodeClaim.Status.ProviderID), nil
 		}
 	}
 

--- a/pkg/cloudprovider/cloudprovider_test.go
+++ b/pkg/cloudprovider/cloudprovider_test.go
@@ -640,3 +640,63 @@ func TestIsDrifted_Location_NilLocation_NoDrift(t *testing.T) {
 		t.Errorf("expected no drift for nil Location, got %q", reason)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Label drift tests (B3)
+// ---------------------------------------------------------------------------
+
+// TestIsDrifted_Labels_Missing verifies that when NodeClass spec.labels contains
+// a key that is absent from the server labels, DriftLabels is returned.
+func TestIsDrifted_Labels_Missing(t *testing.T) {
+	nc := baselineNodeClass()
+	nc.Spec.Labels = map[string]string{"env": "prod"}
+	server := baselineServer()
+	// server has no labels at all → "env" key is missing
+	server.Labels = map[string]string{}
+	cp, nodeClaim := buildCP(t, nc, server)
+	reason, err := cp.IsDrifted(context.Background(), nodeClaim)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reason != cloudprovider.DriftLabels {
+		t.Errorf("want DriftLabels, got %q", reason)
+	}
+}
+
+// TestIsDrifted_Labels_Match verifies that when all NodeClass spec.labels are
+// present and matching on the server, no drift is reported.
+func TestIsDrifted_Labels_Match(t *testing.T) {
+	nc := baselineNodeClass()
+	nc.Spec.Labels = map[string]string{"env": "prod"}
+	server := baselineServer()
+	// server has the required label plus additional management labels (subset rule)
+	server.Labels = map[string]string{
+		"env":                     "prod",
+		"karpenter.sh/managed-by": "karpenter",
+	}
+	cp, nodeClaim := buildCP(t, nc, server)
+	reason, err := cp.IsDrifted(context.Background(), nodeClaim)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reason != "" {
+		t.Errorf("expected no drift when spec labels present+matching, got %q", reason)
+	}
+}
+
+// TestIsDrifted_Labels_Empty verifies that when NodeClass spec.labels is empty
+// (nil), the label check is skipped and no drift is reported.
+func TestIsDrifted_Labels_Empty(t *testing.T) {
+	nc := baselineNodeClass()
+	// Spec.Labels is nil / not set — no requirement
+	server := baselineServer()
+	server.Labels = map[string]string{} // server has no labels either
+	cp, nodeClaim := buildCP(t, nc, server)
+	reason, err := cp.IsDrifted(context.Background(), nodeClaim)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if reason != "" {
+		t.Errorf("expected no drift for empty spec labels, got %q", reason)
+	}
+}

--- a/pkg/controllers/nodeclass/controller.go
+++ b/pkg/controllers/nodeclass/controller.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/equality"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	controllerruntime "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/pkg/providers/imagefamily/imagefamily.go
+++ b/pkg/providers/imagefamily/imagefamily.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/paperclipinc/karpenter-provider-hetzner/pkg/apis/v1alpha1"
 )
@@ -48,15 +49,27 @@ func NewProvider(client ImageClient) *Provider {
 // Resolve returns the best matching image for the given selector and architecture.
 // Supported families: "ubuntu", "talos".
 func (p *Provider) Resolve(ctx context.Context, selector v1alpha1.ImageSelector, arch hcloud.Architecture) (*hcloud.Image, error) {
+	log := logf.FromContext(ctx)
 	ls := labelSelectorString(selector.Selector)
+	var img *hcloud.Image
+	var err error
 	switch strings.ToLower(selector.Family) {
 	case "ubuntu":
-		return p.resolveUbuntu(ctx, selector.Version, arch, ls)
+		img, err = p.resolveUbuntu(ctx, selector.Version, arch, ls)
 	case "talos":
-		return p.resolveTalos(ctx, selector.Version, arch, ls)
+		img, err = p.resolveTalos(ctx, selector.Version, arch, ls)
 	default:
 		return nil, fmt.Errorf("unsupported image family %q: must be one of ubuntu, talos", selector.Family)
 	}
+	if err != nil {
+		return nil, err
+	}
+	log.V(1).Info("resolved image",
+		"family", selector.Family,
+		"arch", string(arch),
+		"imageID", img.ID,
+	)
+	return img, nil
 }
 
 // resolveUbuntu finds a system image whose description contains "ubuntu" and optionally the given version.

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/paperclipinc/karpenter-provider-hetzner/pkg/apis/v1alpha1"
 )
@@ -118,6 +119,7 @@ func (p *Provider) getOrCreatePlacementGroup(ctx context.Context, name string) (
 
 // Create provisions a new Hetzner server, merging Karpenter management labels.
 func (p *Provider) Create(ctx context.Context, opts CreateOpts) (*hcloud.Server, error) {
+	log := logf.FromContext(ctx)
 	labels := make(map[string]string, len(opts.Labels)+3)
 	for k, v := range opts.Labels {
 		labels[k] = v
@@ -198,12 +200,25 @@ func (p *Provider) Create(ctx context.Context, opts CreateOpts) (*hcloud.Server,
 			}
 		}
 	}
+	pgAttached := createOpts.PlacementGroup != nil
+	imageID := int64(0)
+	if opts.Image != nil {
+		imageID = opts.Image.ID
+	}
+	log.Info("created server",
+		"name", opts.Name,
+		"serverType", opts.ServerType,
+		"location", opts.Location,
+		"imageID", imageID,
+		"placementGroupAttached", pgAttached,
+	)
 	return result.Server, nil
 }
 
 // Delete removes the server identified by providerID.
 // If the server is already gone (NotFound), Delete returns nil (idempotent).
 func (p *Provider) Delete(ctx context.Context, providerID string) error {
+	log := logf.FromContext(ctx)
 	id, err := ParseProviderID(providerID)
 	if err != nil {
 		return fmt.Errorf("parsing provider ID %q: %w", providerID, err)
@@ -221,6 +236,7 @@ func (p *Provider) Delete(ctx context.Context, providerID string) error {
 		return nil
 	}
 
+	log.Info("deleting server", "serverID", id)
 	_, _, err = p.client.DeleteWithResult(ctx, server)
 	if err != nil {
 		if hcloud.IsError(err, hcloud.ErrorCodeNotFound) {

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -33,10 +33,10 @@ type ActionWaiter interface {
 
 // Provider wraps hcloud server CRUD operations for Karpenter.
 type Provider struct {
-	client         ServerClient
-	pgClient       PlacementGroupClient
-	waiter         ActionWaiter
-	clusterName    string
+	client      ServerClient
+	pgClient    PlacementGroupClient
+	waiter      ActionWaiter
+	clusterName string
 }
 
 // NewProvider returns a Provider that does NOT wait for hcloud actions to


### PR DESCRIPTION
Workstream B (code hardening) toward v1.0.0.

- **seccompProfile: RuntimeDefault** at pod level in the chart (completes PSS `restricted` compliance).
- **Structured logging** across provider operations (server create/delete with type/location/arch/image + placement-group attach, image resolution, selected instance type, drift-detected with reason+providerID) via controller-runtime's contextual logger.
- **Label drift** (`DriftLabels`): `IsDrifted` flags when the NodeClass `labels` are no longer a subset of the server's labels. Tested (missing / matching / empty).

Gates clean locally: build, test, staticcheck, generate-verify, gofmt. Will run `karpenter-e2e` (drift scenario) after merge to confirm provisioning + drift detection still work with the logging/seccomp changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)