### PR TITLE
docs: examples (talos/ubuntu/multi-arch) + bootstrap guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,17 +127,35 @@ Provisioned nodes carry, in addition to the well-known Karpenter labels:
 | `locations` | `[]string` | yes | — | Hetzner locations (min 1) |
 | `networkID` | `int64` | yes | — | Private network ID nodes attach to |
 | `imageSelector.family` | `talos`\|`ubuntu` | yes | — | OS image family |
-| `imageSelector.version` | `string` | no | newest | Version substring to match |
+| `imageSelector.version` | `string` | no | newest | Version substring to match against the image description |
+| `imageSelector.selector` | `map[string]string` | no | — | hcloud label filter applied when listing images (e.g. `{"caph-image-name": "talos-v1.9.5-gvisor"}`). Prefer this over `version` to pin an exact snapshot (version + baked extensions). All labels must match; the provider guards against provisioning a node whose resolved image arch does not match the server type. |
 | `firewallIDs` | `[]int64` | no | — | Firewalls to attach |
 | `sshKeyIDs` | `[]int64` | no | — | SSH keys to install |
-| `placementGroupStrategy` | `spread`\|`none` | no | `spread` | Placement-group behavior |
-| `enablePublicIPv4` | `bool` | no | `true` | Attach a public IPv4 (billed) |
-| `enablePublicIPv6` | `bool` | no | `true` | Attach a public IPv6 |
-| `labels` | `map[string]string` | no | — | Extra labels on the Hetzner server |
-| `userData` | `string` | no | — | cloud-init / Talos machine config |
-| `userDataSecretRef` | `object {namespace, name, key}` | no | — | Source `userData` from a Secret (keeps secret bootstrap data out of git); takes precedence over `userData` |
+| `placementGroupStrategy` | `spread`\|`none` | no | `spread` | Placement-group behavior. `spread` distributes nodes across physical hosts; `none` disables placement groups. |
+| `enablePublicIPv4` | `*bool` | no | `true` | Attach a public IPv4 (billed separately by Hetzner). Set `false` on private-network clusters to drop the charge. |
+| `enablePublicIPv6` | `*bool` | no | `true` | Attach a public IPv6. |
+| `labels` | `map[string]string` | no | — | Extra hcloud labels on the Hetzner server (useful for cost attribution or firewall label-selectors) |
+| `userData` | `string` | no | — | Inline cloud-init / Talos machine config. Overridden by `userDataSecretRef` when both are set. |
+| `userDataSecretRef` | `object {namespace, name, key}` | no | — | Source `userData` from a Secret instead of inline. The Secret is read at server-create time; its value never appears in the NodeClass spec or git. Takes precedence over `userData`. |
 
-Status exposes `conditions` (`ImagesReady`, `NetworkReady`, `ResourcesReady`, aggregated into `Ready`) and `resolvedImages` (image ID per architecture).
+Status exposes `conditions` (`ImagesReady`, `NetworkReady`, `ResourcesReady`, `UserDataReady`, aggregated into `Ready`) and `resolvedImages` (image ID per architecture).
+
+## Examples
+
+Ready-to-apply examples live in the [`examples/`](examples/) directory.  Each
+file is multi-document YAML (NodeClass + NodePool in one file) with inline
+comments explaining every field.
+
+| File | Description |
+|------|-------------|
+| [`examples/talos-nodeclass.yaml`](examples/talos-nodeclass.yaml) | Talos Linux, private-network cluster, image pinned via label selector, machineconfig from a Secret |
+| [`examples/ubuntu-nodeclass.yaml`](examples/ubuntu-nodeclass.yaml) | Ubuntu 24.04, kubeadm join via inline cloud-init `userData` |
+| [`examples/nodepool-multiarch.yaml`](examples/nodepool-multiarch.yaml) | Multi-arch pattern: one NodeClass, two NodePools (amd64 CCX + arm64 CAX) |
+
+### Bootstrap guides
+
+- [Talos bootstrap guide](docs/talos-bootstrap.md) — obtaining the worker machineconfig, pinning images, and verifying node join.
+- [Ubuntu bootstrap recipe](docs/ubuntu-bootstrap.md) — kubeadm join via cloud-init, keeping tokens out of git, trade-offs vs Talos.
 
 ## Configuration
 

--- a/docs/talos-bootstrap.md
+++ b/docs/talos-bootstrap.md
@@ -1,0 +1,165 @@
+# Talos bootstrap guide
+
+This guide walks through the most common path for provisioning Talos Linux
+worker nodes on Hetzner Cloud with karpenter-provider-hetzner.
+
+See [`examples/talos-nodeclass.yaml`](../examples/talos-nodeclass.yaml) for a
+ready-to-apply NodeClass and NodePool you can adapt.
+
+---
+
+## 1. Why Talos needs a worker machineconfig
+
+Talos does not use cloud-init or SSH.  A node's entire runtime configuration
+comes from a single "machineconfig" YAML document supplied as the server's
+user-data at creation time.  For worker nodes this document must contain:
+
+- The cluster CA certificate (so the worker trusts the control plane).
+- A bootstrap token (so the worker can join via the Kubernetes API).
+- The control-plane endpoint (IP or DNS name + port 6443).
+
+These are secrets.  They must never appear in a NodeClass spec, a Helm values
+file, or any git-tracked file.  `userDataSecretRef` exists precisely to keep
+them out of both.
+
+---
+
+## 2. Obtaining the worker machineconfig
+
+### Option A: `talosctl gen config` (fresh cluster or rotation)
+
+```bash
+# Generate a full set of cluster secrets and configs.
+talosctl gen config <cluster-name> https://<control-plane-ip>:6443 \
+  --output-dir /tmp/talos-configs
+
+# /tmp/talos-configs/worker.yaml is the worker machineconfig.
+# Store it in a Secret immediately; delete the plaintext copy when done.
+```
+
+If your cluster already exists and you need to regenerate configs without
+rotating the CA, pass `--with-secrets <secrets-bundle>` (a file produced by
+`talosctl gen secrets` and stored securely out of band).
+
+### Option B: reuse the worker cloudInit from a cluster-autoscaler-hetzner Secret
+
+If you previously ran
+[cluster-autoscaler-hetzner](https://github.com/johannesfrey/cluster-autoscaler-hetzner),
+your Hetzner project likely has an autoscaler config Secret (often
+`cluster-autoscaler-hetzner` in `kube-system`).  That Secret embeds a
+`worker_cloud_init_<nodepool>` key containing the already-rendered worker
+machineconfig.
+
+```bash
+# Extract it:
+kubectl get secret cluster-autoscaler-hetzner \
+  --namespace kube-system \
+  -o jsonpath='{.data.worker_cloud_init_default}' \
+  | base64 -d > /tmp/worker.yaml
+```
+
+Inspect `/tmp/worker.yaml` to confirm it contains the current cluster CA and a
+valid join token before storing it as a Karpenter Secret (tokens expire).
+
+---
+
+## 3. Store the machineconfig in a Kubernetes Secret
+
+```bash
+kubectl create secret generic talos-worker-machineconfig \
+  --namespace kube-system \
+  --from-file=worker.yaml=/tmp/worker.yaml
+
+# Delete the plaintext copy.
+rm /tmp/worker.yaml
+```
+
+Security considerations:
+
+- Restrict access to the Secret with RBAC.  Only the karpenter-provider-hetzner
+  ServiceAccount needs read access.
+- Kubeadm join tokens expire (default 24 h).  Rotate them before they expire
+  and update the Secret; the provider reads the Secret at server-create time,
+  so a stale token causes new nodes to fail to join.
+- Never commit the Secret manifest with real data.  The commented template in
+  `examples/talos-nodeclass.yaml` is a safe starting point.
+
+---
+
+## 4. Pin the exact image with `imageSelector.selector`
+
+Talos images must match three things simultaneously:
+
+1. The Talos version running on your control plane.
+2. The system extensions baked into the image (e.g. gVisor, NVIDIA drivers).
+3. The CPU architecture of the server type Karpenter selects.
+
+A fuzzy `version` substring match can accidentally resolve an older snapshot
+or one missing a required extension.  Use `imageSelector.selector` to pin the
+exact image by an hcloud label you applied when uploading it:
+
+```bash
+# When you upload your Talos image to Hetzner:
+hcloud image update <image-id> --label caph-image-name=talos-v1.9.5-gvisor
+
+# In the NodeClass:
+imageSelector:
+  family: talos
+  selector:
+    caph-image-name: "talos-v1.9.5-gvisor"
+```
+
+The provider resolves one image per architecture that matches **all** selector
+labels.  If no matching image exists for an architecture that Karpenter wants
+to provision, the provider reports `ImagesReady=False` and logs the missing
+arch — no server is created.  This is the correct safety behavior.
+
+For the multi-arch pattern (amd64 + arm64 NodePools sharing one NodeClass), the
+selector label must be present on both the x86 and ARM snapshots.
+
+---
+
+## 5. Apply the NodeClass and NodePool
+
+```bash
+# Adjust networkID, selector label, Secret name, and locations first.
+kubectl apply -f examples/talos-nodeclass.yaml
+```
+
+Verify the NodeClass becomes Ready:
+
+```bash
+kubectl get hcloudnodeclasses talos-default
+# NAME            READY
+# talos-default   True
+```
+
+If `READY` is `False`, describe the resource and inspect the status conditions:
+
+```bash
+kubectl describe hcloudnodeclass talos-default
+# Look for ImagesReady, NetworkReady, ResourcesReady, UserDataReady.
+```
+
+### Verifying node join
+
+Once a pod is pending and Karpenter provisions a node, watch for it:
+
+```bash
+kubectl get nodes -w
+```
+
+If a node appears but stays `NotReady`, check the Talos API:
+
+```bash
+talosctl --nodes <node-ip> --talosconfig /path/to/talosconfig dmesg | tail -50
+talosctl --nodes <node-ip> --talosconfig /path/to/talosconfig health
+```
+
+Common join failures:
+
+| Symptom | Likely cause |
+|---------|-------------|
+| Node never appears | Token expired; update the Secret and delete the pending NodeClaim so Karpenter retries. |
+| Node appears, `NotReady` | Control-plane endpoint unreachable from the private network; check firewall rules and network routing. |
+| `ImagesReady=False` | No image matches the selector for the requested arch; check `hcloud image list --selector caph-image-name=...`. |

--- a/docs/ubuntu-bootstrap.md
+++ b/docs/ubuntu-bootstrap.md
@@ -1,0 +1,114 @@
+# Ubuntu bootstrap recipe
+
+A concise guide to joining Ubuntu worker nodes via cloud-init and kubeadm with
+karpenter-provider-hetzner.
+
+See [`examples/ubuntu-nodeclass.yaml`](../examples/ubuntu-nodeclass.yaml) for
+an apply-ready NodeClass and NodePool with a full cloud-init template.
+
+---
+
+## How it works
+
+Hetzner Cloud runs the `userData` string as a cloud-init script on first boot.
+The script in `examples/ubuntu-nodeclass.yaml`:
+
+1. Enables required kernel modules and sysctl settings.
+2. Installs containerd with `SystemdCgroup = true`.
+3. Installs kubeadm, kubelet, and kubectl from the Kubernetes apt repository.
+4. Calls `kubeadm join` with the control-plane endpoint, bootstrap token, and
+   CA cert hash.
+
+The node appears in `kubectl get nodes` within two to three minutes of the
+Hetzner server becoming active.
+
+---
+
+## Step 1: generate a kubeadm join command
+
+On an existing control-plane node:
+
+```bash
+kubeadm token create --print-join-command
+# Example output:
+# kubeadm join 10.0.0.2:6443 --token abcdef.0123456789abcdef \
+#   --discovery-token-ca-cert-hash sha256:abc123...
+```
+
+Tokens expire after 24 hours by default.  Generate a new token each time you
+update the user-data Secret or rotate credentials.
+
+---
+
+## Step 2: put the join command in the NodeClass
+
+Replace the three `<PLACEHOLDER>` values in `examples/ubuntu-nodeclass.yaml`:
+
+```yaml
+userData: |
+  #cloud-config
+  runcmd:
+    - kubeadm join <CONTROL_PLANE_ENDPOINT>:6443 \
+        --token <BOOTSTRAP_TOKEN> \
+        --discovery-token-ca-cert-hash sha256:<CA_CERT_HASH>
+```
+
+### Keeping secrets out of git
+
+The bootstrap token carries cluster access.  Consider storing the full
+cloud-init blob in a Kubernetes Secret and referencing it with
+`userDataSecretRef` instead of placing it inline:
+
+```bash
+kubectl create secret generic ubuntu-worker-userdata \
+  --namespace kube-system \
+  --from-file=cloud-init.yaml=/path/to/cloud-init.yaml
+```
+
+```yaml
+# In the NodeClass spec — remove userData and add:
+userDataSecretRef:
+  namespace: kube-system
+  name: ubuntu-worker-userdata
+  key: cloud-init.yaml
+```
+
+`userDataSecretRef` takes precedence over `userData` when both are set.
+
+---
+
+## Step 3: apply and verify
+
+```bash
+kubectl apply -f examples/ubuntu-nodeclass.yaml
+
+# Verify the NodeClass is Ready:
+kubectl get hcloudnodeclasses ubuntu-default
+
+# Watch for new nodes:
+kubectl get nodes -w
+```
+
+If a node does not join within five minutes, SSH to it (while `enablePublicIPv4`
+is `true`, or via Hetzner console) and inspect cloud-init logs:
+
+```bash
+cat /var/log/cloud-init-output.log
+journalctl -u kubelet --no-pager | tail -40
+```
+
+---
+
+## Trade-offs vs Talos
+
+| | Ubuntu + kubeadm | Talos |
+|--|--|--|
+| Custom image required | No (Hetzner public image) | Yes (upload per version + extensions) |
+| SSH access | Yes | No (by design) |
+| Attack surface | Larger (general-purpose OS) | Minimal (immutable, no shell) |
+| Upgrade path | Standard apt + kubeadm upgrade | Talosctl upgrade (atomic) |
+| Bootstrap secret handling | Token in cloud-init (short-lived) | Machineconfig CA + token in Secret |
+| Best fit | Dev/test, mixed workloads | Production, security-focused |
+
+For production clusters, Talos is the recommended path.  See
+[`docs/talos-bootstrap.md`](talos-bootstrap.md) for the full guide.

--- a/examples/nodepool-multiarch.yaml
+++ b/examples/nodepool-multiarch.yaml
@@ -1,0 +1,141 @@
+# Multi-arch NodePool pattern — amd64 + arm64 from a single NodeClass
+#
+# How it works:
+#   - One HCloudNodeClass covers both architectures.  imageSelector.selector
+#     must match images for BOTH amd64 and arm64; the provider resolves one
+#     image ID per architecture and guards against provisioning a node whose
+#     image arch does not match the selected server type.
+#   - TWO NodePools — one per arch — let Karpenter track capacity limits
+#     and disruption budgets independently for each architecture.
+#   - Pods select which arch they run on via nodeAffinity or nodeSelector
+#     on the standard kubernetes.io/arch label.  Pods with no arch preference
+#     land on whichever pool has spare capacity first.
+#
+# Hetzner server families:
+#   amd64: cx (entry), cpx (shared x86), ccx (dedicated x86)
+#   arm64: cax (shared ARM — typically best price/vCPU)
+#
+# Image requirement:
+#   Your Talos (or Ubuntu) images must be uploaded for BOTH architectures.
+#   Use imageSelector.selector to pin a label that is present on both the
+#   x86 and ARM snapshots, e.g. {"caph-image-name": "talos-v1.9.5-gvisor"}
+#   where both images carry that label.  If only one arch has an image with
+#   the selector, the provider will report ImagesReady=False.
+
+apiVersion: karpenter.hetzner.cloud/v1alpha1
+kind: HCloudNodeClass
+metadata:
+  name: talos-multiarch
+spec:
+  locations:
+    - nbg1
+    - fsn1
+    - hel1
+
+  imageSelector:
+    family: talos
+    # ADJUST: this label must be present on BOTH your amd64 and arm64 images.
+    selector:
+      caph-image-name: "talos-v1.9.5-gvisor"
+
+  # ADJUST: replace with your Hetzner private network ID.
+  networkID: 123456
+
+  firewallIDs:
+    - 987654
+
+  placementGroupStrategy: spread
+
+  labels:
+    managed-by: karpenter
+
+  enablePublicIPv4: false
+  enablePublicIPv6: false
+
+  userDataSecretRef:
+    namespace: kube-system
+    name: talos-worker-machineconfig
+    key: worker.yaml
+
+---
+# NodePool: amd64 — x86-64 dedicated CPU (ccx) for latency-sensitive work.
+# Pods select this pool with:
+#   nodeSelector:
+#     kubernetes.io/arch: amd64
+
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: talos-amd64
+spec:
+  template:
+    spec:
+      nodeClassRef:
+        group: karpenter.hetzner.cloud
+        kind: HCloudNodeClass
+        name: talos-multiarch
+
+      requirements:
+        - key: kubernetes.io/arch
+          operator: In
+          values: [amd64]
+
+        # ccx = dedicated x86.  Use cpx for shared x86 at lower cost.
+        - key: karpenter.hetzner.cloud/server-family
+          operator: In
+          values: [ccx]
+
+        - key: topology.kubernetes.io/zone
+          operator: In
+          values: [nbg1, fsn1, hel1]
+
+  limits:
+    cpu: "200"
+    memory: 800Gi
+
+  disruption:
+    consolidationPolicy: WhenEmptyOrUnderutilized
+    consolidateAfter: 30s
+
+---
+# NodePool: arm64 — Hetzner CAX (Ampere Altra) for throughput/cost workloads.
+# Pods select this pool with:
+#   nodeSelector:
+#     kubernetes.io/arch: arm64
+#
+# NOTE: ensure your container images are published as multi-arch manifests
+# (or separate arm64 tags) before sending pods to arm64 nodes.
+
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: talos-arm64
+spec:
+  template:
+    spec:
+      nodeClassRef:
+        group: karpenter.hetzner.cloud
+        kind: HCloudNodeClass
+        name: talos-multiarch
+
+      requirements:
+        - key: kubernetes.io/arch
+          operator: In
+          values: [arm64]
+
+        # cax = Hetzner ARM (Ampere Altra) — shared CPU, best price/vCPU.
+        - key: karpenter.hetzner.cloud/server-family
+          operator: In
+          values: [cax]
+
+        - key: topology.kubernetes.io/zone
+          operator: In
+          values: [nbg1, fsn1, hel1]
+
+  limits:
+    cpu: "200"
+    memory: 800Gi
+
+  disruption:
+    consolidationPolicy: WhenEmptyOrUnderutilized
+    consolidateAfter: 30s

--- a/examples/talos-nodeclass.yaml
+++ b/examples/talos-nodeclass.yaml
@@ -1,0 +1,151 @@
+# Talos Linux NodeClass + NodePool — private-network cluster
+#
+# Prerequisites:
+#   - Hetzner private network created (note the numeric ID).
+#   - Talos images uploaded to your Hetzner project with the label
+#     caph-image-name matching the value below. See docs/talos-bootstrap.md.
+#   - Worker machineconfig stored in a Secret (see bootstrap Secret below).
+#
+# Apply with:
+#   kubectl apply -f examples/talos-nodeclass.yaml
+#
+# NEVER commit real secret data to git.  The bootstrap Secret shown at the
+# bottom of this file is a commented template only.
+
+apiVersion: karpenter.hetzner.cloud/v1alpha1
+kind: HCloudNodeClass
+metadata:
+  name: talos-default
+spec:
+  # locations: at least one Hetzner datacenter region.
+  # Karpenter will spread across them; list all regions you want to use.
+  locations:
+    - nbg1
+    - fsn1
+    - hel1
+
+  imageSelector:
+    family: talos
+    # version is an optional substring match against the image description.
+    # Prefer imageSelector.selector (below) to pin an exact image instead of
+    # relying on substring matching, which may match multiple images.
+    version: "v1.9"
+    # selector is an hcloud label filter applied when listing images.
+    # Use it to pin the exact snapshot that has your Talos version + baked
+    # system extensions (e.g. gVisor, NVIDIA drivers).
+    # ADJUST: replace the value with the caph-image-name label on your image.
+    selector:
+      caph-image-name: "talos-v1.9.5-gvisor"
+
+  # networkID: numeric ID of the Hetzner private network.
+  # ADJUST: replace with your network ID (find it in the Hetzner console or
+  # with `hcloud network list`).
+  networkID: 123456
+
+  # firewallIDs: optional list of Hetzner firewall IDs to attach to each node.
+  # ADJUST or remove if you manage firewall rules elsewhere.
+  firewallIDs:
+    - 987654
+
+  # sshKeyIDs: optional SSH key IDs for emergency console access.
+  # Talos does not use SSH at runtime, but having a key registered can help
+  # with rescue mode operations.
+  # ADJUST or remove.
+  sshKeyIDs:
+    - 42
+
+  # placementGroupStrategy: spread (default) distributes nodes across
+  # physical hosts to reduce correlated failure risk.
+  placementGroupStrategy: spread
+
+  # labels: extra hcloud server labels applied to every node this class
+  # creates.  Useful for cost attribution or hcloud firewall label-selectors.
+  labels:
+    managed-by: karpenter
+    env: production
+
+  # Private-network clusters do not need public IPs.
+  # Disabling both saves the primary-IPv4 charge (billed per server).
+  enablePublicIPv4: false
+  enablePublicIPv6: false
+
+  # userDataSecretRef: source the Talos worker machineconfig from a Secret.
+  # The Secret is read at server-create time and never stored in git or in
+  # the NodeClass spec.
+  # See docs/talos-bootstrap.md for how to create this Secret.
+  userDataSecretRef:
+    namespace: kube-system
+    name: talos-worker-machineconfig
+    key: worker.yaml
+
+---
+# NodePool — constrains what Karpenter may provision for this NodeClass.
+# Karpenter picks the cheapest server type that fits the pending pod's
+# resource request from among the types that satisfy all requirements.
+
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: talos-amd64
+spec:
+  template:
+    spec:
+      # nodeClassRef: must point at the HCloudNodeClass above.
+      nodeClassRef:
+        group: karpenter.hetzner.cloud
+        kind: HCloudNodeClass
+        name: talos-default
+
+      requirements:
+        # Constrain to x86-64 nodes.  Talos images are arch-specific; make
+        # sure your imageSelector.selector value matches this architecture.
+        - key: kubernetes.io/arch
+          operator: In
+          values: [amd64]
+
+        # Constrain to dedicated-CPU families for production workloads.
+        # Remove or adjust to allow shared-CPU types (cpx, cax) as well.
+        - key: karpenter.hetzner.cloud/server-family
+          operator: In
+          values: [ccx]
+
+        # Spread across locations declared in the NodeClass.
+        - key: topology.kubernetes.io/zone
+          operator: In
+          values: [nbg1, fsn1, hel1]
+
+      # Optional: prevent Karpenter from consolidating nodes for 10 minutes
+      # after they are created, giving pods time to warm up.
+      # startupTaints: []
+
+  # Hard ceiling on resources Karpenter may provision for this pool.
+  limits:
+    cpu: "200"
+    memory: 800Gi
+
+  disruption:
+    # WhenEmptyOrUnderutilized consolidates underused nodes automatically.
+    consolidationPolicy: WhenEmptyOrUnderutilized
+    consolidateAfter: 30s
+
+---
+# Bootstrap Secret — TEMPLATE ONLY.
+# DO NOT commit real machineconfig data.
+# See docs/talos-bootstrap.md for how to generate and store this Secret.
+#
+# apiVersion: v1
+# kind: Secret
+# metadata:
+#   name: talos-worker-machineconfig
+#   namespace: kube-system
+# type: Opaque
+# stringData:
+#   # Obtain via:
+#   #   talosctl gen config <cluster-name> https://<control-plane-ip>:6443 \
+#   #     --output-types worker --output /tmp/worker.yaml
+#   # Then:
+#   #   kubectl create secret generic talos-worker-machineconfig \
+#   #     --namespace kube-system \
+#   #     --from-file=worker.yaml=/tmp/worker.yaml
+#   worker.yaml: |
+#     # <paste machineconfig here — keep out of git>

--- a/examples/ubuntu-nodeclass.yaml
+++ b/examples/ubuntu-nodeclass.yaml
@@ -1,0 +1,145 @@
+# Ubuntu NodeClass + NodePool — kubeadm join via inline cloud-init
+#
+# Prerequisites:
+#   - A running Kubernetes control plane reachable from new nodes.
+#   - A valid kubeadm join token + CA cert hash.  Generate with:
+#       kubeadm token create --print-join-command
+#   - The Hetzner private network ID and (optionally) firewall IDs.
+#
+# Apply with:
+#   kubectl apply -f examples/ubuntu-nodeclass.yaml
+#
+# Trade-offs vs Talos:
+#   - Simpler: no custom image needed; Karpenter resolves the latest Ubuntu
+#     image from Hetzner's public catalogue automatically.
+#   - The join token and CA hash appear inline in userData.  Rotate tokens
+#     frequently and consider userDataSecretRef to keep them out of git.
+#     See docs/ubuntu-bootstrap.md for details.
+
+apiVersion: karpenter.hetzner.cloud/v1alpha1
+kind: HCloudNodeClass
+metadata:
+  name: ubuntu-default
+spec:
+  locations:
+    - nbg1
+    - fsn1
+
+  imageSelector:
+    family: ubuntu
+    # version pins the Ubuntu release; omit to always get the newest.
+    # ADJUST: "22.04" or "24.04"
+    version: "24.04"
+
+  # networkID: numeric Hetzner private network ID.
+  # ADJUST: replace with your network ID.
+  networkID: 123456
+
+  # firewallIDs: optional.  ADJUST or remove.
+  firewallIDs:
+    - 987654
+
+  placementGroupStrategy: spread
+
+  labels:
+    managed-by: karpenter
+    env: production
+
+  # enablePublicIPv4: true keeps a public IP so nodes can reach the internet
+  # for apt and kubeadm image pulls.  Set false if you route egress through
+  # NAT or a private registry.
+  enablePublicIPv4: true
+  enablePublicIPv6: false
+
+  # userData: cloud-init script that installs containerd + kubeadm and joins
+  # the cluster.  Replace every <PLACEHOLDER> before applying.
+  #
+  # SECURITY NOTE: the join token carries cluster access.  Consider storing
+  # this blob in a Secret and referencing it via userDataSecretRef instead of
+  # committing it to git.  See docs/ubuntu-bootstrap.md.
+  userData: |
+    #cloud-config
+    package_update: true
+    packages:
+      - apt-transport-https
+      - ca-certificates
+      - curl
+      - gnupg
+
+    runcmd:
+      # ---- kernel settings ----
+      - modprobe overlay
+      - modprobe br_netfilter
+      - |
+        cat <<EOF > /etc/sysctl.d/99-kubernetes.conf
+        net.bridge.bridge-nf-call-iptables  = 1
+        net.bridge.bridge-nf-call-ip6tables = 1
+        net.ipv4.ip_forward                 = 1
+        EOF
+      - sysctl --system
+
+      # ---- containerd ----
+      - curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+      - |
+        echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] \
+        https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
+        > /etc/apt/sources.list.d/docker.list
+      - apt-get update -y
+      - apt-get install -y containerd.io
+      - containerd config default > /etc/containerd/config.toml
+      - sed -i 's/SystemdCgroup = false/SystemdCgroup = true/' /etc/containerd/config.toml
+      - systemctl enable --now containerd
+
+      # ---- kubeadm / kubelet / kubectl ----
+      - curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.31/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+      - echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.31/deb/ /' > /etc/apt/sources.list.d/kubernetes.list
+      - apt-get update -y
+      - apt-get install -y kubelet kubeadm kubectl
+      - apt-mark hold kubelet kubeadm kubectl
+      - systemctl enable kubelet
+
+      # ---- join the cluster ----
+      # ADJUST: replace every <PLACEHOLDER> with real values.
+      # Obtain with: kubeadm token create --print-join-command
+      - |
+        kubeadm join <CONTROL_PLANE_ENDPOINT>:6443 \
+          --token <BOOTSTRAP_TOKEN> \
+          --discovery-token-ca-cert-hash sha256:<CA_CERT_HASH>
+
+---
+# NodePool for Ubuntu nodes — x86-64, shared-CPU (cpx family for cost).
+
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: ubuntu-amd64
+spec:
+  template:
+    spec:
+      nodeClassRef:
+        group: karpenter.hetzner.cloud
+        kind: HCloudNodeClass
+        name: ubuntu-default
+
+      requirements:
+        - key: kubernetes.io/arch
+          operator: In
+          values: [amd64]
+
+        # cpx: shared x86 — good baseline cost/performance for generic workloads.
+        # Add cax (ARM) or ccx (dedicated x86) as additional values if desired.
+        - key: karpenter.hetzner.cloud/server-family
+          operator: In
+          values: [cpx]
+
+        - key: topology.kubernetes.io/zone
+          operator: In
+          values: [nbg1, fsn1]
+
+  limits:
+    cpu: "100"
+    memory: 400Gi
+
+  disruption:
+    consolidationPolicy: WhenEmptyOrUnderutilized
+    consolidateAfter: 30s


### PR DESCRIPTION
Workstream C toward v1.0.0 — adoption docs.

- `examples/talos-nodeclass.yaml`, `examples/ubuntu-nodeclass.yaml`, `examples/nodepool-multiarch.yaml` — apply-ready, commented, using the real spec (`imageSelector.selector`, `userDataSecretRef`, `enablePublicIPv4`, `placementGroupStrategy`).
- `docs/talos-bootstrap.md` — the common Hetzner+Talos setup end to end (worker machineconfig sourcing incl. the autoscaler-secret reuse pattern, Secret + `userDataSecretRef`, image pinning via `imageSelector.selector`, verify).
- `docs/ubuntu-bootstrap.md` — kubeadm/cloud-init recipe + Talos-vs-Ubuntu trade-offs.
- README: new Examples section; field reference gaps filled (`imageSelector.selector`, `*bool` IP toggles, `placementGroupStrategy`, `UserDataReady`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)