### PR TITLE
chore: release v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0] - 2026-06-16
+
+First stable release: a complete CloudProvider implementation with full drift
+detection, observability, supply-chain attestations, and adoption docs.
+
 ### Added
-- Image label selector: `HCloudNodeClass.spec.imageSelector.selector` allows filtering Hetzner images by arbitrary labels, replacing the previous name-only approach (#23).
-- Wrong-arch guard: provisioning is now rejected when the resolved image architecture does not match the requested node architecture (#23).
-- Placement group creation and assignment: the provider now creates and assigns Hetzner placement groups to provisioned servers (#24).
-- Location drift detection: servers whose Hetzner location no longer matches the `NodeClass` spec are detected and disrupted (#24).
-- Label drift detection: servers whose Hetzner server-type labels diverge from the desired state are flagged and reconciled (#26).
-- Structured logging: all log output now uses structured `slog` key-value fields for easier filtering and ingestion (#26).
-- `seccompProfile: RuntimeDefault` on the controller `Deployment` for reduced syscall attack surface (#26).
+- Image label selector: `HCloudNodeClass.spec.imageSelector.selector` filters Hetzner images by arbitrary labels, so you can pin the exact image (version plus baked extensions, e.g. a gVisor-Talos snapshot) instead of fuzzy description matching (#23).
+- Wrong-arch guard: provisioning is rejected when the resolved image architecture does not match the architecture the NodeClaim requires (#23).
+- Placement group creation and assignment: `placementGroupStrategy: spread` now actually creates/assigns a cluster-scoped Hetzner placement group (previously declared but a no-op) (#24).
+- Location drift detection: servers whose Hetzner location is no longer in the NodeClass `locations` are flagged as drifted (#24).
+- Label drift detection: servers whose labels no longer cover the NodeClass `labels` are flagged as drifted (#26).
+- Structured logging across provider operations (server create/delete, image resolution, drift) via the controller-runtime contextual logger (#26).
+- `seccompProfile: RuntimeDefault` on the controller pod for PSS `restricted` compliance (#26).
+- Prometheus metrics (`karpenter_hetzner_*`: server create/delete results and duration, hcloud API calls, drift detections, instance-type cache hits/misses) plus a Helm `ServiceMonitor` (#29).
+- Warning Events from the nodeclass controller on every NotReady path, so `kubectl describe hcloudnodeclass` explains why a class is not Ready (#29).
+- Examples (`talos-nodeclass`, `ubuntu-nodeclass`, `nodepool-multiarch`) and Talos/Ubuntu bootstrap guides (#28).
 
 ### Security
 - Cosign keyless signing of the release image using GitHub OIDC (no long-lived keys).

--- a/README.md
+++ b/README.md
@@ -8,7 +8,12 @@ A [Karpenter](https://karpenter.sh) cloud provider for [Hetzner Cloud](https://w
 
 ## Status
 
-**Alpha.** The provider is correct and deployable, with unit and controller test coverage. End-to-end validation on a live cluster is in progress; treat it as alpha and pin a released image tag rather than `latest` in production.
+**Stable (v1.0.0).** The full CloudProvider surface is implemented with unit and
+controller test coverage, and the provision → join → drift → consolidation
+lifecycle is validated end-to-end against a live Talos cluster (happy, drift,
+consolidation, fallback, and invalid-nodeclass scenarios). Releases are
+multi-arch, cosign-signed, and ship SLSA provenance + an SBOM. Pin a released
+version tag in production.
 
 ## Features
 

--- a/charts/karpenter-provider-hetzner/Chart.yaml
+++ b/charts/karpenter-provider-hetzner/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: karpenter-provider-hetzner
 description: Karpenter cloud provider for Hetzner Cloud
 type: application
-version: 0.3.0
-appVersion: "0.3.0"
+version: 1.0.0
+appVersion: "1.0.0"


### PR DESCRIPTION
Cuts the v1.0.0 release: chart bumped to 1.0.0, CHANGELOG 1.0.0 section, README status flipped to Stable. After merge, tag `v1.0.0` triggers the signed multi-arch image + OCI chart publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)