### PR TITLE
docs(dist): Artifact Hub metadata + distribution checklist

### DIFF
--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -1,0 +1,48 @@
+# Distribution checklist
+
+Steps to make `karpenter-provider-hetzner` discoverable and drive adoption once
+`v1.0.0` is tagged and the signed image + OCI Helm chart are published.
+
+**Backlink strategy:** the anchor is a paperclip.inc page, ideally a blog
+article about the provider (e.g. `https://paperclip.inc/blog/karpenter-hetzner`).
+Every external listing's primary/Homepage link points at paperclip.inc so the
+domain earns the backlinks; the GitHub repo is only the secondary "source" link.
+The chart `home` and Artifact Hub "Homepage" link already point at
+`https://paperclip.inc/karpenter-hetzner` (update to the final blog URL once
+published).
+
+Legend: [auto] doable from a repo · [acct] needs an external account/login ·
+[ext-pr] needs a PR to an external repo.
+
+## Anchor: paperclip.inc blog article  [auto + acct]
+- Write a paperclip.inc engineering blog post ("A production Karpenter provider
+  for Hetzner") in the marketing site, brand-voice compliant. This is the
+  backlink target everything else points at. No fabricated adoption numbers.
+- Optionally a thin `/karpenter-hetzner` landing page that features the post and
+  the install command; set the chart `home` to whichever is canonical.
+
+## Artifact Hub  [acct]
+- Register the OCI chart repo at https://artifacthub.io/control-panel/repositories
+  (Add repository -> Helm charts -> OCI -> `oci://ghcr.io/paperclipinc/charts`).
+- Paste the generated `repositoryID` into `artifacthub-repo.yml`, re-push it to
+  the OCI registry. The chart's `artifacthub.io/*` annotations already set the
+  Homepage link to paperclip.inc.
+
+## karpenter-core community providers docs  [ext-pr]
+- PR to `kubernetes-sigs/karpenter` adding Hetzner to the community/third-party
+  providers list. Link text -> paperclip.inc page; repo as the code link.
+
+## awesome-karpenter  [ext-pr]
+- PR to the `awesome-karpenter` providers section. Primary link -> paperclip.inc
+  page; mention the repo.
+
+## CNCF landscape  [ext-pr]
+- PR to `cncf/landscape` under the autoscaling category (homepage_url ->
+  paperclip.inc, repo_url -> GitHub, license Apache-2.0).
+
+## Hetzner community  [acct]
+- Tutorial on the Hetzner Community portal: "Autoscale a Talos k8s cluster on
+  Hetzner with Karpenter", linking the paperclip.inc article.
+
+## README badges  [auto]
+- Add the Artifact Hub badge once the listing exists.

--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,0 +1,13 @@
+# Artifact Hub repository metadata for the OCI Helm chart.
+# Push this to the OCI registry alongside the chart so Artifact Hub can verify
+# ownership:
+#   oci://ghcr.io/paperclipinc/charts
+# See https://artifacthub.io/docs/topics/repositories/helm-charts/#oci-registries
+#
+# repositoryID is issued by Artifact Hub when the repo is first registered at
+# https://artifacthub.io/control-panel/repositories (add repo -> Helm charts ->
+# OCI registry URL above). Paste the generated ID here, then re-push this file.
+repositoryID: ""
+owners:
+  - name: paperclip.inc
+    email: ops@paperclip.inc

--- a/charts/karpenter-provider-hetzner/Chart.yaml
+++ b/charts/karpenter-provider-hetzner/Chart.yaml
@@ -4,3 +4,26 @@ description: Karpenter cloud provider for Hetzner Cloud
 type: application
 version: 1.0.0
 appVersion: "1.0.0"
+# home points at paperclip.inc (the project's canonical page) so listing
+# "Homepage" links drive backlinks to the domain; GitHub stays as source.
+home: https://paperclip.inc/karpenter-hetzner
+sources:
+  - https://github.com/paperclipinc/karpenter-provider-hetzner
+keywords:
+  - karpenter
+  - hetzner
+  - autoscaling
+  - node-provisioning
+maintainers:
+  - name: paperclip.inc
+    url: https://paperclip.inc
+annotations:
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/links: |
+    - name: Homepage
+      url: https://paperclip.inc/karpenter-hetzner
+    - name: source
+      url: https://github.com/paperclipinc/karpenter-provider-hetzner
+    - name: Talos bootstrap guide
+      url: https://github.com/paperclipinc/karpenter-provider-hetzner/blob/main/docs/talos-bootstrap.md
+  artifacthub.io/category: integration-delivery


### PR DESCRIPTION
Workstream F (provider side): chart Artifact Hub annotations + maintainer/home pointing at paperclip.inc (backlinks accrue to the domain, GitHub stays source), `artifacthub-repo.yml` for OCI ownership, and `DISTRIBUTION.md` listing the external submissions (Artifact Hub, karpenter community docs, awesome-karpenter, CNCF landscape, Hetzner tutorial) with the paperclip.inc blog article as the anchor. The blog article + external submissions are tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)