### PR TITLE
chore: Artifact Hub repository ID + badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![CI](https://github.com/paperclipinc/karpenter-provider-hetzner/actions/workflows/ci.yaml/badge.svg)](https://github.com/paperclipinc/karpenter-provider-hetzner/actions/workflows/ci.yaml)
 [![Go Report Card](https://goreportcard.com/badge/github.com/paperclipinc/karpenter-provider-hetzner)](https://goreportcard.com/report/github.com/paperclipinc/karpenter-provider-hetzner)
 [![License](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](LICENSE)
+[![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/karpenter-provider-hetzner)](https://artifacthub.io/packages/helm/karpenter-provider-hetzner/karpenter-provider-hetzner)
 
 A [Karpenter](https://karpenter.sh) cloud provider for [Hetzner Cloud](https://www.hetzner.com/cloud). It provisions, bin-packs, and autoscales Hetzner Cloud servers as Kubernetes nodes, picking the cost-optimal server type for pending pods from Hetzner's real-time pricing.
 

--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -7,7 +7,7 @@
 # repositoryID is issued by Artifact Hub when the repo is first registered at
 # https://artifacthub.io/control-panel/repositories (add repo -> Helm charts ->
 # OCI registry URL above). Paste the generated ID here, then re-push this file.
-repositoryID: ""
+repositoryID: b74823b2-1844-44eb-ab1b-5517fb941926
 owners:
   - name: paperclip.inc
     email: ops@paperclip.inc


### PR DESCRIPTION
Records the Artifact Hub repositoryID (already pushed to the OCI registry as the ownership-claim metadata artifact) and adds the Artifact Hub badge to the README. The chart repo is registered at `oci://ghcr.io/paperclipinc/charts/karpenter-provider-hetzner` and will be indexed + ownership-verified on the next AH scan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)