### PR TITLE
docs: capitalize Paperclip.inc in prose

### DIFF
--- a/DISTRIBUTION.md
+++ b/DISTRIBUTION.md
@@ -3,9 +3,9 @@
 Steps to make `karpenter-provider-hetzner` discoverable and drive adoption once
 `v1.0.0` is tagged and the signed image + OCI Helm chart are published.
 
-**Backlink strategy:** the anchor is a paperclip.inc page, ideally a blog
+**Backlink strategy:** the anchor is a Paperclip.inc page, ideally a blog
 article about the provider (e.g. `https://paperclip.inc/blog/karpenter-hetzner`).
-Every external listing's primary/Homepage link points at paperclip.inc so the
+Every external listing's primary/Homepage link points at Paperclip.inc so the
 domain earns the backlinks; the GitHub repo is only the secondary "source" link.
 The chart `home` and Artifact Hub "Homepage" link already point at
 `https://paperclip.inc/karpenter-hetzner` (update to the final blog URL once
@@ -14,8 +14,8 @@ published).
 Legend: [auto] doable from a repo · [acct] needs an external account/login ·
 [ext-pr] needs a PR to an external repo.
 
-## Anchor: paperclip.inc blog article  [auto + acct]
-- Write a paperclip.inc engineering blog post ("A production Karpenter provider
+## Anchor: Paperclip.inc blog article  [auto + acct]
+- Write a Paperclip.inc engineering blog post ("A production Karpenter provider
   for Hetzner") in the marketing site, brand-voice compliant. This is the
   backlink target everything else points at. No fabricated adoption numbers.
 - Optionally a thin `/karpenter-hetzner` landing page that features the post and
@@ -26,23 +26,23 @@ Legend: [auto] doable from a repo · [acct] needs an external account/login ·
   (Add repository -> Helm charts -> OCI -> `oci://ghcr.io/paperclipinc/charts`).
 - Paste the generated `repositoryID` into `artifacthub-repo.yml`, re-push it to
   the OCI registry. The chart's `artifacthub.io/*` annotations already set the
-  Homepage link to paperclip.inc.
+  Homepage link to Paperclip.inc.
 
 ## karpenter-core community providers docs  [ext-pr]
 - PR to `kubernetes-sigs/karpenter` adding Hetzner to the community/third-party
-  providers list. Link text -> paperclip.inc page; repo as the code link.
+  providers list. Link text -> Paperclip.inc page; repo as the code link.
 
 ## awesome-karpenter  [ext-pr]
-- PR to the `awesome-karpenter` providers section. Primary link -> paperclip.inc
+- PR to the `awesome-karpenter` providers section. Primary link -> Paperclip.inc
   page; mention the repo.
 
 ## CNCF landscape  [ext-pr]
 - PR to `cncf/landscape` under the autoscaling category (homepage_url ->
-  paperclip.inc, repo_url -> GitHub, license Apache-2.0).
+  Paperclip.inc, repo_url -> GitHub, license Apache-2.0).
 
 ## Hetzner community  [acct]
 - Tutorial on the Hetzner Community portal: "Autoscale a Talos k8s cluster on
-  Hetzner with Karpenter", linking the paperclip.inc article.
+  Hetzner with Karpenter", linking the Paperclip.inc article.
 
 ## README badges  [auto]
 - Add the Artifact Hub badge once the listing exists.

--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -9,5 +9,5 @@
 # OCI registry URL above). Paste the generated ID here, then re-push this file.
 repositoryID: b74823b2-1844-44eb-ab1b-5517fb941926
 owners:
-  - name: paperclip.inc
+  - name: Paperclip.inc
     email: ops@paperclip.inc

--- a/charts/karpenter-provider-hetzner/Chart.yaml
+++ b/charts/karpenter-provider-hetzner/Chart.yaml
@@ -4,7 +4,7 @@ description: Karpenter cloud provider for Hetzner Cloud
 type: application
 version: 1.0.0
 appVersion: "1.0.0"
-# home points at paperclip.inc (the project's canonical page) so listing
+# home points at Paperclip.inc (the project's canonical page) so listing
 # "Homepage" links drive backlinks to the domain; GitHub stays as source.
 home: https://paperclip.inc/karpenter-hetzner
 sources:
@@ -15,7 +15,7 @@ keywords:
   - autoscaling
   - node-provisioning
 maintainers:
-  - name: paperclip.inc
+  - name: Paperclip.inc
     url: https://paperclip.inc
 annotations:
   artifacthub.io/license: Apache-2.0


### PR DESCRIPTION
Brand rule: Paperclip.inc is capitalized in prose; URLs, the paperclipinc org handle, and the ops@ email stay lowercase. Fixes DISTRIBUTION.md prose, the artifacthub-repo.yml owner name, and the Chart.yaml maintainer name + comment (home URL unchanged).