### PR TITLE
fix: return NodeClaimNotFoundError when deleting an already-gone server

### DIFF
--- a/pkg/cloudprovider/cloudprovider_test.go
+++ b/pkg/cloudprovider/cloudprovider_test.go
@@ -385,14 +385,18 @@ func TestGetInstanceTypes_NilNodePool(t *testing.T) {
 // Edge-case tests
 // ---------------------------------------------------------------------------
 
-// TestDelete_Idempotent verifies that deleting a NodeClaim whose backing server
-// no longer exists (or never did) is a no-op and returns nil.
-func TestDelete_Idempotent(t *testing.T) {
+// TestDelete_NotFoundReturnsNodeClaimNotFound verifies that deleting a NodeClaim
+// whose backing server no longer exists surfaces a NodeClaimNotFoundError — the
+// signal Karpenter's termination controller uses to finalize the NodeClaim.
+func TestDelete_NotFoundReturnsNodeClaimNotFound(t *testing.T) {
 	cp, _, _ := buildCPWithTypes(t, baselineNodeClass(), []*hcloud.ServerType{cx22Type()})
 	nodeClaim := &karpv1.NodeClaim{}
 	nodeClaim.Status.ProviderID = instance.FormatProviderID(12345) // not seeded
-	if err := cp.Delete(context.Background(), nodeClaim); err != nil {
-		t.Errorf("Delete of missing server should be nil, got %v", err)
+	// Deleting an already-gone server must surface as NodeClaimNotFoundError so
+	// Karpenter's termination controller can finalize the NodeClaim instead of
+	// requeueing forever (which leaks the NodeClaim).
+	if err := cp.Delete(context.Background(), nodeClaim); !karpcp.IsNodeClaimNotFoundError(err) {
+		t.Errorf("expected NodeClaimNotFoundError for missing server, got %v", err)
 	}
 }
 

--- a/pkg/providers/instance/instance.go
+++ b/pkg/providers/instance/instance.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	karpcp "sigs.k8s.io/karpenter/pkg/cloudprovider"
 
 	apiv1 "github.com/paperclipinc/karpenter-provider-hetzner/pkg/apis/v1"
 	"github.com/paperclipinc/karpenter-provider-hetzner/pkg/metrics"
@@ -229,12 +230,17 @@ func (p *Provider) create(ctx context.Context, opts CreateOpts) (*hcloud.Server,
 	return result.Server, nil
 }
 
-// Delete removes the server identified by providerID.
-// If the server is already gone (NotFound), Delete returns nil (idempotent).
+// Delete removes the server identified by providerID. It returns nil once the
+// deletion has been triggered (Hetzner deletes asynchronously), and a
+// cloudprovider.NodeClaimNotFoundError once the server no longer exists — the
+// signal Karpenter's termination controller uses to finalize the NodeClaim.
 func (p *Provider) Delete(ctx context.Context, providerID string) error {
 	err := p.delete(ctx, providerID)
+	// A NodeClaimNotFoundError means the instance is already terminated, which is
+	// the expected steady-state result of a completed deletion — not a failure —
+	// so it must not be counted as a server-delete error.
 	result := metrics.ResultSuccess
-	if err != nil {
+	if err != nil && !karpcp.IsNodeClaimNotFoundError(err) {
 		result = metrics.ResultError
 	}
 	metrics.RecordServerDelete(result)
@@ -252,20 +258,23 @@ func (p *Provider) delete(ctx context.Context, providerID string) error {
 	server, _, err := p.client.GetByID(ctx, id)
 	if err != nil {
 		if hcloud.IsError(err, hcloud.ErrorCodeNotFound) {
-			return nil
+			return karpcp.NewNodeClaimNotFoundError(fmt.Errorf("server %d not found", id))
 		}
 		return fmt.Errorf("getting server %d: %w", id, err)
 	}
 	if server == nil {
-		// Server not found.
-		return nil
+		// Server already gone. Per the CloudProvider.Delete contract, return a
+		// NodeClaimNotFoundError (not nil) once the instance is terminated — it is
+		// the signal Karpenter's termination controller uses to remove the NodeClaim
+		// finalizer. Returning nil makes it requeue indefinitely and leaks the NodeClaim.
+		return karpcp.NewNodeClaimNotFoundError(fmt.Errorf("server %d not found", id))
 	}
 
 	log.Info("deleting server", "serverID", id)
 	_, _, err = p.client.DeleteWithResult(ctx, server)
 	if err != nil {
 		if hcloud.IsError(err, hcloud.ErrorCodeNotFound) {
-			return nil
+			return karpcp.NewNodeClaimNotFoundError(fmt.Errorf("server %d not found", id))
 		}
 		return fmt.Errorf("deleting server %d: %w", id, err)
 	}

--- a/pkg/providers/instance/instance_test.go
+++ b/pkg/providers/instance/instance_test.go
@@ -32,6 +32,7 @@ type mockServerClient struct {
 	action           *hcloud.Action
 	nextActions      []*hcloud.Action
 	createErr        error
+	deleteErr        error
 	lastOpts         hcloud.ServerCreateOpts
 }
 
@@ -55,6 +56,9 @@ func (m *mockServerClient) Create(_ context.Context, opts hcloud.ServerCreateOpt
 }
 
 func (m *mockServerClient) DeleteWithResult(_ context.Context, server *hcloud.Server) (*hcloud.ServerDeleteResult, *hcloud.Response, error) {
+	if m.deleteErr != nil {
+		return nil, nil, m.deleteErr
+	}
 	delete(m.servers, server.ID)
 	m.deleted = append(m.deleted, server.ID)
 	return &hcloud.ServerDeleteResult{}, nil, nil
@@ -144,14 +148,32 @@ func TestDelete_RemovesServer(t *testing.T) {
 	}
 }
 
-func TestDelete_Idempotent(t *testing.T) {
-	// Deleting a server that doesn't exist should not return an error.
+func TestDelete_NotFoundReturnsNodeClaimNotFound(t *testing.T) {
+	// Deleting a server that no longer exists must return a NodeClaimNotFoundError
+	// (not nil). Karpenter's termination controller calls Delete each reconcile and
+	// only removes the NodeClaim finalizer once Delete reports the instance is gone;
+	// returning nil makes it requeue forever and leaks the NodeClaim.
 	client := newMockServerClient()
 	p := NewProvider(client, "test-cluster")
 
 	err := p.Delete(context.Background(), "hcloud://999")
-	if err != nil {
-		t.Fatalf("expected nil error for non-existent server, got: %v", err)
+	if !karpcp.IsNodeClaimNotFoundError(err) {
+		t.Fatalf("expected NodeClaimNotFoundError for non-existent server, got: %v", err)
+	}
+}
+
+func TestDelete_RaceDeletedReturnsNodeClaimNotFound(t *testing.T) {
+	// The server exists at GetByID but is already gone by DeleteWithResult (e.g. a
+	// concurrent delete in the Hetzner console). Delete must still surface a
+	// NodeClaimNotFoundError so the NodeClaim can be finalized.
+	client := newMockServerClient()
+	client.servers[55] = &hcloud.Server{ID: 55, Name: "node-55"}
+	client.deleteErr = hcloud.Error{Code: hcloud.ErrorCodeNotFound, Message: "not found"}
+	p := NewProvider(client, "test-cluster")
+
+	err := p.Delete(context.Background(), "hcloud://55")
+	if !karpcp.IsNodeClaimNotFoundError(err) {
+		t.Fatalf("expected NodeClaimNotFoundError on delete race, got: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

`Provider.Delete` returns `nil` when the target server no longer exists — on a `GetByID` not-found, a nil server, or a `DeleteWithResult` not-found. But Karpenter's termination controller calls `CloudProvider.Delete` on every reconcile and only removes the NodeClaim's `karpenter.sh/termination` finalizer once `Delete` reports the instance is gone via a `NodeClaimNotFoundError` (see the `nodeclaim/lifecycle` finalize path in `sigs.k8s.io/karpenter`). Because `Delete` returned `nil`, that controller requeues indefinitely — so **every terminated node leaves its NodeClaim stuck in `Terminating`**: the server and `Node` object are gone, but the NodeClaim object is never finalized (and it survives a controller restart).

This matches the `CloudProvider.Delete` interface contract in `pkg/cloudprovider/types.go`: return `NodeClaimNotFoundError` when the instance is already terminated, and `nil` when deletion was only triggered.

## Changes

- `Provider.Delete` now returns `cloudprovider.NewNodeClaimNotFoundError` in the three "server already gone" paths instead of `nil`. A successful `DeleteWithResult` still returns `nil` — Hetzner deletes asynchronously, so the instance is confirmed gone on a later reconcile, which then hits the not-found path and finalizes the NodeClaim.
- The metrics wrapper no longer counts a `NodeClaimNotFoundError` as a `server_delete` error — it's the expected end-of-termination signal, not a failure.
- Updated the two delete tests that asserted the old nil-on-not-found behavior, and added a test for the concurrent-delete race (`DeleteWithResult` returning not-found).

## Verification

- `go build ./...`, `go vet ./...` — clean
- `go test -race ./...` — all packages pass
- `make generate-verify` — unaffected (no API type changes)
- `gofmt` — clean

Reproduced on a private k3s cluster: after consolidation and scale-to-zero the servers + `Node` objects were deleted, but the NodeClaims stayed `Terminating` with the `karpenter.sh/termination` finalizer indefinitely (surviving a controller restart) until removed by hand. With this change the NodeClaim finalizes on the next reconcile after the server is gone.