### PR TITLE
fix(chart): pin the operator image to the chart's appVersion

### DIFF
--- a/charts/karpenter-provider-hetzner/templates/deployment.yaml
+++ b/charts/karpenter-provider-hetzner/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: controller
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
             - name: HCLOUD_TOKEN

--- a/charts/karpenter-provider-hetzner/values.yaml
+++ b/charts/karpenter-provider-hetzner/values.yaml
@@ -2,7 +2,10 @@ replicas: 1
 
 image:
   repository: ghcr.io/paperclipinc/karpenter-provider-hetzner
-  tag: latest
+  # Empty tracks the chart's appVersion, which the release workflow sets from
+  # the git tag and publishes as a matching image tag. Pinning "latest" here
+  # meant a released chart floated onto whatever was newest.
+  tag: ""
   pullPolicy: IfNotPresent
 
 auth:


### PR DESCRIPTION
Found while preparing the v2.0.0 release.

`values.yaml` pinned `image.tag: latest`, so an installed chart floated onto whatever was newest in the registry instead of the version it was published as — a 2.0.0 chart could silently run a 3.x operator, and a rollback to an older chart wouldn't roll back the operator.

The release workflow already makes the correct value available: it publishes bare semver image tags (`type=semver,pattern={{version}}` and `{{major}}.{{minor}}`) and packages the chart with `--app-version` from the git tag, so `appVersion` always names a published image tag. (Note this differs from hermes-operator, which publishes `v`-prefixed tags — here the bare form is correct.)

```
image.tag: ""
image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
```

Verified three ways:

| path | rendered |
|---|---|
| chart defaults | `...:2.0.0` |
| `--set image.tag=1.2.3` | `...:1.2.3` |
| `helm package --version 2.0.0 --app-version 2.0.0` (as the release job runs) | `...:2.0.0` |

`helm lint` and `go test ./...` pass.