### PR TITLE
fix: alias hcloud CSI location topology so PVC pods can provision

### DIFF
--- a/pkg/apis/v1/labels.go
+++ b/pkg/apis/v1/labels.go
@@ -8,6 +8,12 @@ const (
 	LabelServerFamily = Group + "/server-family"
 	LabelLocation     = Group + "/location"
 
+	// LabelCSILocation is the topology domain the hcloud CSI driver uses for
+	// PersistentVolume nodeAffinity and CSINode topology (see
+	// hetznercloud/csi-driver#333). It is aliased to topology.kubernetes.io/zone
+	// in normalizedlabels.go so Karpenter can volume-schedule PVC pods.
+	LabelCSILocation = "csi.hetzner.cloud/location"
+
 	ProviderIDPrefix = "hcloud://"
 
 	ServerLabelManagedBy = "karpenter.sh/managed-by"

--- a/pkg/apis/v1/normalizedlabels.go
+++ b/pkg/apis/v1/normalizedlabels.go
@@ -1,0 +1,26 @@
+package v1
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+)
+
+// The hcloud CSI driver pins PersistentVolume nodeAffinity (and reports CSINode
+// topology) on the domain csi.hetzner.cloud/location. The driver deliberately
+// uses this key and reverted from the standard topology labels
+// (hetznercloud/csi-driver#333), so it cannot be changed upstream.
+//
+// Karpenter only recognizes the standard topology.kubernetes.io/zone, so
+// without this alias it rejects every pod that carries an hcloud PVC with
+// "label csi.hetzner.cloud/location does not have known values". Alias the CSI
+// domain to the standard zone label that this provider already stamps on its
+// offerings (pkg/providers/instancetype), so PV nodeAffinity constrains node
+// provisioning. This mirrors how karpenter-provider-aws aliases
+// topology.ebs.csi.aws.com/zone.
+//
+// It is safe without value remapping: the hcloud CSI driver reports the same
+// location names (nbg1, fsn1, hel1, ...) that this provider derives from the
+// hcloud pricing API.
+func init() {
+	karpv1.NormalizedLabels[LabelCSILocation] = corev1.LabelTopologyZone
+}

--- a/pkg/apis/v1/normalizedlabels_test.go
+++ b/pkg/apis/v1/normalizedlabels_test.go
@@ -1,0 +1,24 @@
+package v1
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/karpenter/pkg/scheduling"
+)
+
+func TestCSILocationNormalizedToTopologyZone(t *testing.T) {
+	// A requirement built from the hcloud CSI domain must normalize to the
+	// standard zone label while preserving the location value, so that PV
+	// nodeAffinity like "csi.hetzner.cloud/location In [nbg1]" constrains node
+	// provisioning the same way "topology.kubernetes.io/zone In [nbg1]" does.
+	req := scheduling.NewRequirement(LabelCSILocation, corev1.NodeSelectorOpIn, "nbg1")
+
+	if req.Key != corev1.LabelTopologyZone {
+		t.Fatalf("requirement key = %q, want %q (csi.hetzner.cloud/location must normalize to the standard zone label)",
+			req.Key, corev1.LabelTopologyZone)
+	}
+	if req.Any() != "nbg1" {
+		t.Errorf("requirement value = %q, want %q (location value must be preserved)", req.Any(), "nbg1")
+	}
+}


### PR DESCRIPTION
## Summary

Karpenter could not provision nodes for pods that carry an hcloud CSI volume, failing with:

```
incompatible volume requirements, label "csi.hetzner.cloud/location" does not have known values
```

The hcloud CSI driver pins PersistentVolume `nodeAffinity` on the topology domain `csi.hetzner.cloud/location`, which Karpenter does not recognize (it only knows the standard `topology.kubernetes.io/zone`). As a result this provider could only provision for PVC-less pods; pods bound to an hcloud PVC could not trigger node provisioning themselves. The driver deliberately uses this key and reverted from the standard topology labels (hetznercloud/csi-driver#333), so the fix belongs in the provider.

## Changes

- Alias `csi.hetzner.cloud/location` → `topology.kubernetes.io/zone` via `karpv1.NormalizedLabels` (new `pkg/apis/v1/normalizedlabels.go`), mirroring how `karpenter-provider-aws` aliases `topology.ebs.csi.aws.com/zone`.
- Add the `LabelCSILocation` constant.

## Verification

- [x] `make test` passes
- [x] `make lint` passes (0 issues)
- [x] `make generate-verify` passes (no CRD/deepcopy changes)
- [x] Added `TestCSILocationNormalizedToTopologyZone` — verifies a requirement built from `csi.hetzner.cloud/location` normalizes to `topology.kubernetes.io/zone` while preserving the location value.

This is value-safe: the CSI driver reports the same location names (`nbg1`, `fsn1`, `hel1`, …) the provider derives from the hcloud pricing API, so no value remapping is required.

## Notes

- No NodePool or StorageClass changes are needed; existing PVs with `csi.hetzner.cloud/location In [nbg1]` start constraining provisioning immediately.
- No breaking changes.
