### PR TITLE
feat(chart): expose scheduling values, command/args, and an optional PDB

### DIFF
--- a/charts/karpenter-provider-hetzner/Chart.yaml
+++ b/charts/karpenter-provider-hetzner/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: karpenter-provider-hetzner
 description: Karpenter cloud provider for Hetzner Cloud
 type: application
-version: 2.0.0
+version: 2.1.0
 appVersion: "2.0.0"
 # home points at Paperclip.inc (the project's canonical page) so listing
 # "Homepage" links drive backlinks to the domain; GitHub stays as source.
@@ -31,7 +31,5 @@ annotations:
   artifacthub.io/category: integration-delivery
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
-    - kind: changed
-      description: "BREAKING: HCloudNodeClass graduated from karpenter.hetzner.cloud/v1alpha1 to /v1; re-apply node classes (no conversion webhook)"
     - kind: added
-      description: "k3s agent bootstrap example and guide (examples/k3s-nodeclass.yaml, docs/k3s-bootstrap.md)"
+      description: "Expose nodeSelector, affinity, tolerations, topologySpreadConstraints, imagePullSecrets, priorityClassName, command, args and an optional PodDisruptionBudget (minAvailable or maxUnavailable) on the Deployment via chart values"

--- a/charts/karpenter-provider-hetzner/README.md
+++ b/charts/karpenter-provider-hetzner/README.md
@@ -39,7 +39,8 @@ Existing `v1alpha1` objects are not migrated automatically; recreate them under
 | `clusterName` | `""` (required) | Scopes which servers the controller manages |
 | `replicas` | `1` | Controller replicas |
 | `image.repository` | `ghcr.io/paperclipinc/karpenter-provider-hetzner` | Image |
-| `image.tag` | `latest` | Pin a released tag in production |
+| `image.tag` | `""` | Empty tracks the chart appVersion; pin a tag in production |
+| `image.pullPolicy` | `IfNotPresent` | Image pull policy |
 | `auth.secretRef.name` | `hcloud-token` | Secret holding the Hetzner token |
 | `auth.secretRef.key` | `token` | Key within the secret |
 | `serviceAccount.create` | `true` | Create the service account |
@@ -47,11 +48,36 @@ Existing `v1alpha1` objects are not migrated automatically; recreate them under
 | `metrics.port` | `8080` | Prometheus metrics port |
 | `healthProbe.port` | `8081` | Health/readiness probe port |
 | `resources` | see values.yaml | Container resources |
+| `nodeSelector` | `{}` | Pin the controller pod to specific nodes |
+| `affinity` | `{}` | `nodeAffinity` / `podAntiAffinity` |
+| `tolerations` | `[]` | Tolerate node taints |
+| `topologySpreadConstraints` | `[]` | Spread replicas across nodes/zones; needs a labelSelector matching the pod labels |
+| `imagePullSecrets` | `[]` | Pull from a private registry mirror |
+| `priorityClassName` | `""` | Pod priority class |
+| `podDisruptionBudget.enabled` | `false` | Create a PodDisruptionBudget (enable with `replicas > 1`) |
+| `podDisruptionBudget.minAvailable` | unset | Positive integer; mutually exclusive with `maxUnavailable` |
+| `podDisruptionBudget.maxUnavailable` | `1` (default) | Positive integer; never blocks drains (run `replicas >= 2` for availability) |
+| `command` | `[]` | Override the container entrypoint (advanced) |
+| `args` | `[]` | Controller flags, e.g. `--log-level`, `--feature-gates` |
 | `serviceMonitor.enabled` | `false` | Deploy a Service + ServiceMonitor for Prometheus Operator |
 | `serviceMonitor.interval` | `30s` | Scrape interval |
 | `serviceMonitor.additionalLabels` | `{}` | Extra labels on the ServiceMonitor (for Prometheus Operator selector) |
 
 The CRD is installed from `crds/` automatically by Helm.
+
+## Scheduling
+
+`nodeSelector`, `affinity`, `tolerations`, `topologySpreadConstraints`,
+`imagePullSecrets` and `priorityClassName` pass straight through to the
+Deployment pod spec; `command` and `args` pass through to the container (the
+hardcoded probes expect `/healthz` and `/readyz`, so a custom command must serve
+them). All default to empty. Leader election is enabled by default, so `replicas > 1` won't
+double-reconcile — only the leader acts. For drain safety with `replicas > 1`,
+enable `podDisruptionBudget`: it defaults to `maxUnavailable: 1`, which never
+blocks drains (a single replica can still be evicted, so run `replicas >= 2` to
+keep the controller available). Configs that would block all voluntary drains
+(`minAvailable >= replicas` or `maxUnavailable: 0`) are rejected by design —
+checked at install/upgrade, so runtime scaling is the operator's responsibility.
 
 ## Prometheus Operator integration
 

--- a/charts/karpenter-provider-hetzner/templates/_helpers.tpl
+++ b/charts/karpenter-provider-hetzner/templates/_helpers.tpl
@@ -1,0 +1,19 @@
+{{/*
+Validate that value is a decimal integer in a small range; fail the render with
+a clear message otherwise. The bound (0/1-999999) stays below 1e6 so Helm's
+float64/scientific-notation coercion (e.g. 1000000 -> "1e+06") can't slip a
+value past the regex. Set allowZero=true to permit 0 (replicas); otherwise >= 1.
+
+Usage: {{ include "karpenter-hetzner.requireInt" (dict "value" .Values.replicas "name" "replicas" "allowZero" true) }}
+*/}}
+{{- define "karpenter-hetzner.requireInt" -}}
+{{- $re := "^[1-9][0-9]{0,5}$" -}}
+{{- $range := "1-999999" -}}
+{{- if .allowZero -}}
+{{- $re = "^(0|[1-9][0-9]{0,5})$" -}}
+{{- $range = "0-999999" -}}
+{{- end -}}
+{{- if not (regexMatch $re (printf "%v" .value)) -}}
+{{- fail (printf "%s must be an integer (%s), got %v" .name $range .value) -}}
+{{- end -}}
+{{- end -}}

--- a/charts/karpenter-provider-hetzner/templates/deployment.yaml
+++ b/charts/karpenter-provider-hetzner/templates/deployment.yaml
@@ -1,6 +1,7 @@
 {{- if not .Values.clusterName }}
 {{- fail "clusterName is required: set --set clusterName=<your-cluster>" }}
 {{- end }}
+{{- include "karpenter-hetzner.requireInt" (dict "value" .Values.replicas "name" "replicas" "allowZero" true) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -10,7 +11,7 @@ metadata:
     app.kubernetes.io/name: karpenter-provider-hetzner
     app.kubernetes.io/instance: {{ .Release.Name }}
 spec:
-  replicas: {{ .Values.replicas }}
+  replicas: {{ .Values.replicas | int }}
   selector:
     matchLabels:
       app.kubernetes.io/name: karpenter-provider-hetzner
@@ -21,6 +22,29 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
     spec:
       serviceAccountName: {{ .Values.serviceAccount.name }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . | quote }}
+      {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       securityContext:
         seccompProfile:
           type: RuntimeDefault
@@ -28,6 +52,14 @@ spec:
         - name: controller
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.command }}
+          command:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.args }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
             - name: HCLOUD_TOKEN
               valueFrom:

--- a/charts/karpenter-provider-hetzner/templates/poddisruptionbudget.yaml
+++ b/charts/karpenter-provider-hetzner/templates/poddisruptionbudget.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+{{- $pdb := .Values.podDisruptionBudget }}
+{{- $hasMin := hasKey $pdb "minAvailable" }}
+{{- $hasMax := hasKey $pdb "maxUnavailable" }}
+{{- if and $hasMin $hasMax }}
+{{- fail "podDisruptionBudget: set minAvailable OR maxUnavailable, not both." }}
+{{- end }}
+{{- if $hasMin }}
+{{- include "karpenter-hetzner.requireInt" (dict "value" $pdb.minAvailable "name" "podDisruptionBudget.minAvailable") }}
+{{- if ge (int $pdb.minAvailable) (int .Values.replicas) }}
+{{- fail "podDisruptionBudget.minAvailable must be < replicas: minAvailable >= replicas makes the Deployment un-evictable and blocks all voluntary drains." }}
+{{- end }}
+{{- end }}
+{{- if $hasMax }}
+{{- include "karpenter-hetzner.requireInt" (dict "value" $pdb.maxUnavailable "name" "podDisruptionBudget.maxUnavailable") }}
+{{- end }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: karpenter-provider-hetzner
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: karpenter-provider-hetzner
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  {{- if $hasMin }}
+  minAvailable: {{ $pdb.minAvailable | int }}
+  {{- else if $hasMax }}
+  maxUnavailable: {{ $pdb.maxUnavailable | int }}
+  {{- else }}
+  maxUnavailable: 1
+  {{- end }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: karpenter-provider-hetzner
+{{- end }}

--- a/charts/karpenter-provider-hetzner/values.yaml
+++ b/charts/karpenter-provider-hetzner/values.yaml
@@ -25,6 +25,30 @@ resources:
     cpu: 500m
     memory: 256Mi
 
+# Pod scheduling & placement. All empty by default — opt in via values.
+nodeSelector: {}
+affinity: {}
+tolerations: []
+topologySpreadConstraints: []
+imagePullSecrets: []
+priorityClassName: ""
+
+# PodDisruptionBudget for voluntary-disruption safety (e.g. node drains). Enable
+# when running replicas > 1. Set minAvailable OR maxUnavailable (integers only,
+# mutually exclusive — no percentages); leave both unset to default to
+# maxUnavailable: 1, which never blocks drains (a single replica can still be
+# evicted — run replicas >= 2 to keep the controller available).
+podDisruptionBudget:
+  enabled: false
+  # minAvailable: 1   # must be < replicas (so needs replicas >= 2)
+  # maxUnavailable: 1
+
+# Container launch overrides. `args` passes flags to the controller (e.g.
+# --log-level, --feature-gates); `command` replaces the entrypoint binary (rarely
+# needed — the hardcoded probes expect /healthz and /readyz).
+command: []
+args: []
+
 # Required: scopes managed servers so multiple clusters can share one Hetzner project.
 clusterName: ""
 


### PR DESCRIPTION
## What

Exposes pod-scheduling and container-launch knobs on the controller Deployment via chart values. All new values are empty by default, so existing releases render unchanged (additive, non-breaking).

## Values added

| Area | Keys |
|---|---|
| Pod scheduling | `nodeSelector`, `affinity`, `tolerations`, `topologySpreadConstraints`, `imagePullSecrets`, `priorityClassName` |
| Container | `command`, `args` |
| Availability | `podDisruptionBudget` (optional) |

## PodDisruptionBudget

Off by default; when enabled it defaults to `maxUnavailable: 1` (self-scaling, never blocks drains). `minAvailable` and `maxUnavailable` are mutually exclusive positive integers, and `minAvailable >= replicas` — the un-evictable footgun — is rejected at render time. Enable with `replicas > 1` (run `replicas >= 2` to keep the controller available during drains).

## Notes

- `replicas` is validated as a non-negative integer at render time (rejects non-numeric / leading-zero / out-of-range input with a clear message).
- Chart bumped to `2.1.0` (`appVersion` unchanged — no image change).
- README gains Values table rows + a Scheduling section; also corrects a pre-existing stale `image.tag` default (`latest` → `""` / tracks `appVersion`).

Rendered manifests validated with `helm lint` and `kubeconform` (k8s 1.28) across default and fully-configured installs.
