### PR TITLE
chore(release): v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.0] - 2026-08-01
+
+### Fixed
+- Pods bound to an hcloud CSI volume can now trigger provisioning. The hcloud CSI driver pins `PersistentVolume` `nodeAffinity` on `csi.hetzner.cloud/location`, which Karpenter did not recognize, so volume-topology scheduling rejected every PVC-backed pod with `label "csi.hetzner.cloud/location" does not have known values`. That domain is now aliased to the standard `topology.kubernetes.io/zone` via `NormalizedLabels`, mirroring how `karpenter-provider-aws` aliases `topology.ebs.csi.aws.com/zone`. No NodePool or StorageClass changes are needed (#46).
+
+### Added
+- Chart: `nodeSelector`, `affinity`, `tolerations`, `topologySpreadConstraints`, `imagePullSecrets`, `priorityClassName`, `command` and `args` on the controller Deployment. All empty by default, so existing releases render unchanged (#47).
+- Chart: optional `podDisruptionBudget` (off by default; `maxUnavailable: 1` when enabled). `minAvailable` and `maxUnavailable` are mutually exclusive positive integers, and configurations that would block all voluntary drains (`minAvailable >= replicas`, `maxUnavailable: 0`) are rejected at render time. `replicas` is likewise validated as a non-negative integer (#47).
+
+## [2.0.0] - 2026-07-28
+
+### Changed
+- **BREAKING:** `HCloudNodeClass` graduated from `karpenter.hetzner.cloud/v1alpha1` to `karpenter.hetzner.cloud/v1`. There is no conversion webhook — update `apiVersion` in your manifests and re-apply your node classes (#37).
+
+### Added
+- k3s agent bootstrap support: `examples/k3s-nodeclass.yaml` and `docs/k3s-bootstrap.md`.
+- Artifact Hub repository ID and badge (#32).
+
+### Fixed
+- The chart ships the Karpenter core CRDs (`NodePool`, `NodeClaim`), so a clean install no longer leaves the controller crash-looping on its own watches. Both are vendored from the pinned `sigs.k8s.io/karpenter` during `make generate`, so a dependency bump that changes either schema fails the `generate-verify` CI gate instead of shipping a stale CRD (#44).
+- The operator image is pinned to the chart's `appVersion` instead of floating on `:latest`, so an installed chart runs the operator it was published with (#45).
+- Return `NodeClaimNotFoundError` when deleting an already-gone server, instead of a hard error (#40).
+
+### Changed (dependencies)
+- Bumped `sigs.k8s.io/karpenter`, `hetznercloud/hcloud-go`, and GitHub Actions (#34, #35, #36, #39, #41, #42).
+- CI reads the Go version from `go.mod` instead of pinning it.
+
 ## [1.0.0] - 2026-06-16
 
 First stable release: a complete CloudProvider implementation with full drift
@@ -59,7 +86,10 @@ detection, observability, supply-chain attestations, and adoption docs.
 - Grant full Karpenter-core RBAC in Helm chart (#13).
 - Treat `unsupported location for server type` as an unavailable offering rather than a hard error (#16).
 
-[Unreleased]: https://github.com/paperclipinc/karpenter-provider-hetzner/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/paperclipinc/karpenter-provider-hetzner/compare/v2.1.0...HEAD
+[2.1.0]: https://github.com/paperclipinc/karpenter-provider-hetzner/compare/v2.0.0...v2.1.0
+[2.0.0]: https://github.com/paperclipinc/karpenter-provider-hetzner/compare/v1.0.0...v2.0.0
+[1.0.0]: https://github.com/paperclipinc/karpenter-provider-hetzner/compare/v0.3.0...v1.0.0
 [0.3.0]: https://github.com/paperclipinc/karpenter-provider-hetzner/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/paperclipinc/karpenter-provider-hetzner/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/paperclipinc/karpenter-provider-hetzner/releases/tag/v0.1.0

--- a/charts/karpenter-provider-hetzner/Chart.yaml
+++ b/charts/karpenter-provider-hetzner/Chart.yaml
@@ -3,7 +3,7 @@ name: karpenter-provider-hetzner
 description: Karpenter cloud provider for Hetzner Cloud
 type: application
 version: 2.1.0
-appVersion: "2.0.0"
+appVersion: "2.1.0"
 # home points at Paperclip.inc (the project's canonical page) so listing
 # "Homepage" links drive backlinks to the domain; GitHub stays as source.
 home: https://paperclip.inc/karpenter-hetzner
@@ -31,5 +31,7 @@ annotations:
   artifacthub.io/category: integration-delivery
   artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
+    - kind: fixed
+      description: "Pods bound to an hcloud CSI volume can now trigger provisioning: csi.hetzner.cloud/location is aliased to topology.kubernetes.io/zone"
     - kind: added
       description: "Expose nodeSelector, affinity, tolerations, topologySpreadConstraints, imagePullSecrets, priorityClassName, command, args and an optional PodDisruptionBudget (minAvailable or maxUnavailable) on the Deployment via chart values"


### PR DESCRIPTION
Release prep for **v2.1.0**, bundling #46 (CSI location alias) and #47 (chart scheduling values + PDB).

## Changes

- **`appVersion` → 2.1.0.** #47 bumped the chart to 2.1.0 but left `appVersion` at 2.0.0, so `helm install ./charts` from a git checkout would have pulled the 2.0.0 image — i.e. without #46's CSI fix. The published chart is unaffected (`release.yaml` packages with `--version`/`--app-version` from the git tag); this just makes the source tree self-consistent.
- **CHANGELOG backfill.** 2.0.0 shipped without a CHANGELOG entry and the compare links stopped at 0.3.0. Adds the 2.1.0 and 2.0.0 sections and the 1.0.0/2.0.0/2.1.0 links.
- **Artifact Hub changes** annotation gains the CSI fix alongside the chart values entry.

## Verification

- `make test` green (all 8 packages).
- `helm lint` clean; default render now resolves `ghcr.io/paperclipinc/karpenter-provider-hetzner:2.1.0`.

Tagging `v2.1.0` after merge; the release workflow publishes the multi-arch image and the OCI chart, then this goes through the e2e scenarios on the mono cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)