### PR TITLE
feat: report nodes Karpenter cannot price

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,56 @@ version tag in production.
 
 A `NodePool` references an `HCloudNodeClass`. When pods are unschedulable, Karpenter asks this provider for instance types, picks the cheapest compatible offering, creates the server, and the node joins the cluster.
 
+### Node zone labels and consolidation
+
+Offerings are keyed on the Hetzner **location** — `topology.kubernetes.io/zone=nbg1`.
+Karpenter prices a running node by looking its zone and capacity-type up against
+its instance type's offerings, so a node's zone label has to be a location too.
+
+`hcloud-cloud-controller-manager` labels nodes with the legacy **datacenter**
+(`nbg1-dc3`) by default. That lookup misses, the node prices at zero, and because
+nothing is cheaper than zero every candidate replacement is rejected. Karpenter
+reports `Unconsolidatable: "Can't replace with a cheaper node"` on every node,
+indefinitely — which reads like a considered decision rather than a broken
+lookup.
+
+The tell is two signals together:
+
+```
+karpenter_nodepools_cost_total   -> non-zero and correct
+every disruption decision        -> savings: $0.00
+```
+
+Both at once is conclusive. Cost stays right because it reads the NodeClaim's
+labels, not the Node's, so spend looks healthy while rightsizing is dead.
+
+**Fix:** set `HCLOUD_INSTANCES_ZONE_LABEL_ENABLED=false` on the CCM (v1.35.0+).
+Karpenter's registration then fills the label from the NodeClaim, giving the
+location. Two caveats: it applies only at node initialization, so existing nodes
+must be recreated; and it is cluster-wide, so any node Karpenter does *not*
+register ends up with no zone label at all — which fails to price for the same
+reason.
+
+`karpenter_hetzner_nodes_price_unresolved` counts registered Karpenter-owned
+nodes whose price does not resolve, whatever the cause, and the operator logs a
+sample with their instance type and zone. Anything above zero means
+consolidation is disabled for that many nodes.
+
+Alert on it together with `karpenter_hetzner_price_health_scan_total`. A gauge
+reads zero from process start, so "no broken nodes" and "the check has never
+run" are the same number; only a rising `result="success"` says the zero is real.
+Aggregate with `max()` across replicas, since the check runs on the leader and a
+standby reports zero.
+
+The check asks each NodePool for its own instance types rather than the whole
+catalogue, because that is what Karpenter prices against: narrowing a
+NodeClass's `locations` leaves existing nodes outside it unpriceable, and a
+catalogue-wide lookup would resolve them and report healthy.
+
+Hetzner removes datacenters from its API on 2026-10-01, after which the CCM's
+zone label has to change anyway, so the datacenter half of this may resolve
+itself. The missing-label half will not.
+
 ## Installation
 
 You need a Hetzner Cloud API token with read/write access and a Kubernetes cluster on Hetzner (the [hcloud Cloud Controller Manager](https://github.com/hetznercloud/hcloud-cloud-controller-manager) should set node provider IDs as `hcloud://<id>`).

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -16,6 +16,7 @@ import (
 
 	hetznercp "github.com/paperclipinc/karpenter-provider-hetzner/pkg/cloudprovider"
 	"github.com/paperclipinc/karpenter-provider-hetzner/pkg/controllers/nodeclass"
+	"github.com/paperclipinc/karpenter-provider-hetzner/pkg/controllers/pricehealth"
 	hetznerop "github.com/paperclipinc/karpenter-provider-hetzner/pkg/operator"
 	"github.com/paperclipinc/karpenter-provider-hetzner/pkg/providers/imagefamily"
 	"github.com/paperclipinc/karpenter-provider-hetzner/pkg/providers/instance"
@@ -60,6 +61,13 @@ func main() {
 	// Our NodeClass status controller (network + image validation, Ready).
 	nodeClassController := nodeclass.NewController(op.GetClient(), &hcloudClient.Network, &hcloudClient.Firewall, &hcloudClient.SSHKey, imageProvider)
 
+	// Report nodes Karpenter cannot price. A node priced at zero can never be
+	// consolidated, and the resulting "Can't replace with a cheaper node" reads
+	// as a decision rather than a broken lookup, so the failure is otherwise
+	// silent. Takes the decorated cloud provider because that is what core prices
+	// against: per NodePool, filtered to that NodeClass's locations.
+	priceHealthController := pricehealth.NewController(op.GetClient(), cloudProvider)
+
 	// Wire and start all controllers.
 	op.WithControllers(ctx, append(
 		controllers.NewControllers(
@@ -74,5 +82,6 @@ func main() {
 			op.InstanceTypeStore,
 		),
 		nodeClassController,
+		priceHealthController,
 	)...).Start(ctx)
 }

--- a/pkg/controllers/pricehealth/controller.go
+++ b/pkg/controllers/pricehealth/controller.go
@@ -1,0 +1,225 @@
+// Package pricehealth reports Karpenter-owned nodes that Karpenter cannot price.
+//
+// Karpenter prices a running node by looking its zone and capacity-type up
+// against the offerings of its instance type. A miss returns zero, and a node
+// priced at zero can never be consolidated: nothing is cheaper than zero, so
+// every candidate replacement is rejected and the decision is logged as
+// "Can't replace with a cheaper node" — which reads like a considered choice
+// rather than a broken lookup.
+//
+// That silence is the whole problem. The cost metric keeps reporting correctly
+// throughout, because it reads the NodeClaim's labels rather than the Node's, so
+// spend looks right while rightsizing is dead. On this provider the usual cause
+// is hcloud-cloud-controller-manager labelling nodes with the legacy datacenter
+// (nbg1-dc3) while offerings are keyed on the location (nbg1); disabling that
+// label leaves unregistered nodes with no zone at all, which fails the same way.
+//
+// This controller runs the same lookup Karpenter does and counts the misses, so
+// the failure is a number on a dashboard instead of a plausible-looking log line.
+package pricehealth
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/awslabs/operatorpkg/reconciler"
+	"github.com/awslabs/operatorpkg/singleton"
+	corev1 "k8s.io/api/core/v1"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	karpcp "sigs.k8s.io/karpenter/pkg/cloudprovider"
+	"sigs.k8s.io/karpenter/pkg/operator/injection"
+
+	apiv1 "github.com/paperclipinc/karpenter-provider-hetzner/pkg/apis/v1"
+	"github.com/paperclipinc/karpenter-provider-hetzner/pkg/metrics"
+)
+
+const (
+	// resyncInterval is how often nodes are re-checked. This detects a
+	// misconfiguration that persists until someone fixes it, so it does not need
+	// the cadence of a controller that reacts to churn.
+	resyncInterval = 5 * time.Minute
+
+	// maxLoggedNodes caps how many unpriced nodes are named in one log line. The
+	// headline cause -- the CCM's datacenter zone label -- is the *default*
+	// configuration and misses on every node at once, so the common case is a
+	// fleet-sized list, not a handful. An uncapped line is tens of kilobytes every
+	// resync, which log pipelines truncate or drop, losing the examples that name
+	// the cause. The count is exact regardless; the list is a sample.
+	maxLoggedNodes = 10
+)
+
+// CatalogueProvider is the narrow API this controller needs: the instance types
+// Karpenter itself would price a NodePool's nodes against.
+//
+// It has to be per-NodePool. Karpenter never prices against the whole catalogue:
+// core builds its map from CloudProvider.GetInstanceTypes(ctx, nodePool), which
+// this provider answers by filtering to the NodeClass's locations (a required,
+// min-1 field) and by applying any NodeOverlay pricing. Asking for every
+// instance type in every location would resolve offerings Karpenter has already
+// filtered away -- reporting healthy in exactly the case this controller exists
+// to catch.
+type CatalogueProvider interface {
+	GetInstanceTypes(ctx context.Context, nodePool *karpv1.NodePool) ([]*karpcp.InstanceType, error)
+}
+
+// Controller counts Karpenter-owned nodes whose price does not resolve.
+type Controller struct {
+	kubeClient client.Client
+	catalogues CatalogueProvider
+}
+
+func NewController(kubeClient client.Client, catalogues CatalogueProvider) *Controller {
+	return &Controller{kubeClient: kubeClient, catalogues: catalogues}
+}
+
+func (c *Controller) Name() string { return "pricehealth" }
+
+// unpricedNode is one node Karpenter cannot price, with the labels that explain
+// why. Reporting the values is the point: "zone=nbg1-dc3" names the cause where
+// a bare count would only say something is wrong.
+//
+// The fields are exported with JSON tags because that is what makes them appear
+// in a log line. The logger encodes arbitrary values by reflection and never
+// consults fmt.Stringer, so unexported fields render as "nodes":[{}] -- a log
+// that looks informative and carries nothing.
+type unpricedNode struct {
+	Node         string `json:"node"`
+	InstanceType string `json:"instanceType"`
+	Zone         string `json:"zone"`
+	CapacityType string `json:"capacityType"`
+}
+
+func (c *Controller) Reconcile(ctx context.Context) (reconciler.Result, error) {
+	ctx = injection.WithControllerName(ctx, c.Name())
+	log := logf.FromContext(ctx)
+
+	unresolved, err := c.scan(ctx)
+	if err != nil {
+		// Leave the gauge alone -- zeroing it here would report every node as
+		// healthy whenever the catalogue is unreachable. That is not enough on its
+		// own, though: a gauge reads zero from process start, so "no broken nodes"
+		// and "never managed to look" are the same number. The counter is what
+		// separates them, and it is the reason this swallowed error stays visible.
+		metrics.RecordPriceHealthScan(metrics.ResultError)
+		log.Error(err, "checking whether nodes can be priced")
+		return reconciler.Result{RequeueAfter: resyncInterval}, nil
+	}
+
+	// Always publish, including zero, so the gauge falls back to healthy once the
+	// cause is fixed rather than staying latched at its worst value.
+	metrics.SetNodesPriceUnresolved(len(unresolved))
+	metrics.RecordPriceHealthScan(metrics.ResultSuccess)
+
+	if len(unresolved) > 0 {
+		sample := unresolved
+		if len(sample) > maxLoggedNodes {
+			sample = sample[:maxLoggedNodes]
+		}
+		log.Info("nodes cannot be priced, so Karpenter cannot consolidate them; "+
+			"check that the node zone label matches a Hetzner location",
+			"count", len(unresolved), "nodes", sample)
+	}
+	return reconciler.Result{RequeueAfter: resyncInterval}, nil
+}
+
+// scan returns the Karpenter-owned nodes whose price does not resolve, running
+// the same offering lookup Karpenter itself performs.
+func (c *Controller) scan(ctx context.Context) ([]unpricedNode, error) {
+	byNodePool, err := c.catalogueByNodePool(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	// Only nodes Karpenter owns. Control-plane and hand-built nodes are not its to
+	// price, and flagging them would bury the real signal. Selecting server-side
+	// also keeps the cache from deep-copying every unmanaged Node in the cluster.
+	nodes := &corev1.NodeList{}
+	if err := c.kubeClient.List(ctx, nodes, client.HasLabels{karpv1.NodePoolLabelKey}); err != nil {
+		return nil, fmt.Errorf("listing nodes: %w", err)
+	}
+
+	var unresolved []unpricedNode
+	for i := range nodes.Items {
+		n := &nodes.Items[i]
+		// Until registration completes, Karpenter prices a node from its NodeClaim's
+		// labels rather than the Node's (state.StateNode.Labels), and the Node's zone
+		// label is written by that same registration. An unregistered node is
+		// mid-handshake, not broken; counting it would leave the gauge permanently
+		// non-zero on any cluster that is still scaling.
+		if n.Labels[karpv1.NodeRegisteredLabelKey] != "true" {
+			continue
+		}
+		// A NodePool this provider does not serve belongs to another cloud provider
+		// in the same cluster; its nodes are not ours to price.
+		catalogue, ok := byNodePool[n.Labels[karpv1.NodePoolLabelKey]]
+		if !ok {
+			continue
+		}
+		candidate := unpricedNode{
+			Node:         n.Name,
+			InstanceType: n.Labels[corev1.LabelInstanceTypeStable],
+			Zone:         n.Labels[corev1.LabelTopologyZone],
+			CapacityType: n.Labels[karpv1.CapacityTypeLabelKey],
+		}
+		it, ok := catalogue[candidate.InstanceType]
+		if !ok {
+			// An instance type missing from the catalogue prices at zero just the
+			// same, so it belongs in the count even though the cause differs.
+			unresolved = append(unresolved, candidate)
+			continue
+		}
+		// A matching offering is not enough: consolidation is disabled by the price
+		// being zero, not by the lookup missing. hcloud can return a server type
+		// whose pricing payload does not parse, and the catalogue keeps the offering
+		// with Price 0 -- so an offering that resolves to zero (or NaN, which core
+		// also maps to zero) fails in exactly the same way as no offering at all.
+		if price, ok := it.OfferingPrice(candidate.Zone, candidate.CapacityType); !ok || price <= 0 || math.IsNaN(price) {
+			unresolved = append(unresolved, candidate)
+		}
+	}
+	return unresolved, nil
+}
+
+// catalogueByNodePool returns, per NodePool this provider serves, the instance
+// types Karpenter prices that pool's nodes against, indexed by name.
+func (c *Controller) catalogueByNodePool(ctx context.Context) (map[string]map[string]*karpcp.InstanceType, error) {
+	nodePools := &karpv1.NodePoolList{}
+	if err := c.kubeClient.List(ctx, nodePools); err != nil {
+		return nil, fmt.Errorf("listing nodepools: %w", err)
+	}
+
+	out := make(map[string]map[string]*karpcp.InstanceType, len(nodePools.Items))
+	for i := range nodePools.Items {
+		np := &nodePools.Items[i]
+		// Skip pools belonging to another provider before asking for their instance
+		// types: resolving a NodeClass we do not own would fail, and a failure has
+		// to stay meaningful -- it is what stops a broken scan reporting healthy.
+		if np.Spec.Template.Spec.NodeClassRef == nil || np.Spec.Template.Spec.NodeClassRef.Group != apiv1.Group {
+			continue
+		}
+		instanceTypes, err := c.catalogues.GetInstanceTypes(ctx, np)
+		if err != nil {
+			return nil, fmt.Errorf("listing instance types for nodepool %s: %w", np.Name, err)
+		}
+		byName := make(map[string]*karpcp.InstanceType, len(instanceTypes))
+		for _, it := range instanceTypes {
+			byName[it.Name] = it
+		}
+		out[np.Name] = byName
+	}
+	return out, nil
+}
+
+// Register wires the controller into the manager.
+func (c *Controller) Register(_ context.Context, m manager.Manager) error {
+	return controllerruntime.NewControllerManagedBy(m).
+		Named(c.Name()).
+		WatchesRawSource(singleton.Source()).
+		Complete(singleton.AsReconciler(c))
+}

--- a/pkg/controllers/pricehealth/controller_test.go
+++ b/pkg/controllers/pricehealth/controller_test.go
@@ -1,0 +1,365 @@
+package pricehealth
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/go-logr/zapr"
+	"github.com/prometheus/client_golang/prometheus"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+	karpcp "sigs.k8s.io/karpenter/pkg/cloudprovider"
+	"sigs.k8s.io/karpenter/pkg/scheduling"
+
+	apiv1 "github.com/paperclipinc/karpenter-provider-hetzner/pkg/apis/v1"
+)
+
+const testNodePool = "default"
+
+// fakeCatalogue answers per NodePool, the way the real cloud provider does: each
+// pool sees only the instance types its NodeClass locations allow.
+type fakeCatalogue struct {
+	byNodePool map[string][]*karpcp.InstanceType
+	err        error
+	asked      []string
+}
+
+func (f *fakeCatalogue) GetInstanceTypes(_ context.Context, np *karpv1.NodePool) ([]*karpcp.InstanceType, error) {
+	if f.err != nil {
+		return nil, f.err
+	}
+	f.asked = append(f.asked, np.Name)
+	return f.byNodePool[np.Name], nil
+}
+
+// offering builds one priced offering for a zone -- the shape this provider
+// actually builds, one per pricing location.
+func offering(zone string, price float64) *karpcp.Offering {
+	return &karpcp.Offering{
+		Requirements: scheduling.NewRequirements(
+			scheduling.NewRequirement(karpv1.CapacityTypeLabelKey, corev1.NodeSelectorOpIn, karpv1.CapacityTypeOnDemand),
+			scheduling.NewRequirement(corev1.LabelTopologyZone, corev1.NodeSelectorOpIn, zone),
+		),
+		Price:     price,
+		Available: true,
+	}
+}
+
+// catalogue is cx43 priced in the given zones, scoped to the default NodePool.
+func catalogue(offerings ...*karpcp.Offering) map[string][]*karpcp.InstanceType {
+	return map[string][]*karpcp.InstanceType{
+		testNodePool: {{Name: "cx43", Offerings: offerings}},
+	}
+}
+
+func nbg1Catalogue() map[string][]*karpcp.InstanceType {
+	return catalogue(offering("nbg1", 0.0242))
+}
+
+// nodePool builds a NodePool this provider serves.
+func nodePool(name string) *karpv1.NodePool {
+	np := &karpv1.NodePool{ObjectMeta: metav1.ObjectMeta{Name: name}}
+	np.Spec.Template.Spec.NodeClassRef = &karpv1.NodeClassReference{
+		Group: apiv1.Group,
+		Kind:  "HCloudNodeClass",
+		Name:  "default",
+	}
+	return np
+}
+
+// node builds a registered Karpenter-owned node with the labels core prices from.
+func node(name, instanceType, zone string) *corev1.Node {
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				karpv1.NodePoolLabelKey:        testNodePool,
+				karpv1.NodeRegisteredLabelKey:  "true",
+				corev1.LabelInstanceTypeStable: instanceType,
+				corev1.LabelTopologyZone:       zone,
+				karpv1.CapacityTypeLabelKey:    karpv1.CapacityTypeOnDemand,
+			},
+		},
+	}
+}
+
+func newFakeClient(objs ...client.Object) client.Client {
+	return fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(objs...).Build()
+}
+
+// newTestController wires a controller over the default NodePool plus the given
+// nodes.
+func newTestController(types map[string][]*karpcp.InstanceType, nodes ...client.Object) *Controller {
+	objs := append([]client.Object{nodePool(testNodePool)}, nodes...)
+	return NewController(newFakeClient(objs...), &fakeCatalogue{byNodePool: types})
+}
+
+// metricValue returns the current value of a single-series metric family.
+func metricValue(t *testing.T, name string) float64 {
+	t.Helper()
+	mfs, err := crmetrics.Registry.(prometheus.Gatherer).Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	for _, mf := range mfs {
+		if mf.GetName() != name {
+			continue
+		}
+		var total float64
+		for _, m := range mf.GetMetric() {
+			if g := m.GetGauge(); g != nil {
+				total += g.GetValue()
+			}
+			if c := m.GetCounter(); c != nil {
+				total += c.GetValue()
+			}
+		}
+		return total
+	}
+	return 0
+}
+
+func scan(t *testing.T, c *Controller) []unpricedNode {
+	t.Helper()
+	unresolved, err := c.scan(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	return unresolved
+}
+
+func TestReconcile_HealthyNodeResolves(t *testing.T) {
+	c := newTestController(nbg1Catalogue(), node("worker", "cx43", "nbg1"))
+
+	if unresolved := scan(t, c); len(unresolved) != 0 {
+		t.Errorf("a correctly labelled node failed to price: %v", unresolved)
+	}
+}
+
+// The failure this exists to catch. hcloud-cloud-controller-manager labels
+// nodes with the legacy datacenter by default, while offerings are keyed on the
+// location, so the lookup misses and Karpenter prices the node at zero.
+func TestReconcile_DatacenterZoneDoesNotResolve(t *testing.T) {
+	c := newTestController(nbg1Catalogue(), node("worker", "cx43", "nbg1-dc3"))
+
+	unresolved := scan(t, c)
+	if len(unresolved) != 1 || unresolved[0].Node != "worker" {
+		t.Errorf("expected the datacenter-labelled node flagged, got %v", unresolved)
+	}
+}
+
+// Disabling the CCM's zone label leaves nodes Karpenter never registers with no
+// zone at all -- created by the very workaround recommended for the case above,
+// and permanent, unlike the datacenter labels.
+func TestReconcile_MissingZoneDoesNotResolve(t *testing.T) {
+	n := node("worker", "cx43", "")
+	delete(n.Labels, corev1.LabelTopologyZone)
+	c := newTestController(nbg1Catalogue(), n)
+
+	if unresolved := scan(t, c); len(unresolved) != 1 {
+		t.Errorf("expected the zone-less node flagged, got %v", unresolved)
+	}
+}
+
+// An instance type absent from the catalogue cannot be priced either -- the same
+// consolidation failure, a different cause.
+func TestReconcile_UnknownInstanceTypeDoesNotResolve(t *testing.T) {
+	c := newTestController(nbg1Catalogue(), node("worker", "cx99", "nbg1"))
+
+	if unresolved := scan(t, c); len(unresolved) != 1 {
+		t.Errorf("expected the unknown-type node flagged, got %v", unresolved)
+	}
+}
+
+// Karpenter never prices against the whole catalogue: it asks the cloud provider
+// per NodePool, which filters to that NodeClass's locations. A node in a zone
+// the pool no longer covers prices at zero for core, so checking an unfiltered
+// catalogue would report it healthy -- the exact silence this controller exists
+// to break.
+func TestReconcile_ZoneOutsideTheNodePoolsCatalogueDoesNotResolve(t *testing.T) {
+	types := &fakeCatalogue{byNodePool: nbg1Catalogue()}
+	c := NewController(newFakeClient(nodePool(testNodePool), node("worker", "cx43", "fsn1")), types)
+
+	unresolved := scan(t, c)
+	if len(unresolved) != 1 || unresolved[0].Zone != "fsn1" {
+		t.Errorf("expected the out-of-catalogue node flagged, got %v", unresolved)
+	}
+	// Pin the mechanism, not just the outcome: the catalogue has to be requested
+	// per NodePool. A global lookup would resolve offerings core has filtered away.
+	if len(types.asked) != 1 || types.asked[0] != testNodePool {
+		t.Errorf("catalogue requested for %v, want exactly [%s]", types.asked, testNodePool)
+	}
+}
+
+// A matching offering is not enough. Consolidation is disabled by the price being
+// zero, and hcloud can return a server type whose pricing does not parse, which
+// the catalogue keeps as an offering priced at zero.
+func TestReconcile_ZeroPricedOfferingDoesNotResolve(t *testing.T) {
+	c := newTestController(catalogue(offering("nbg1", 0)), node("worker", "cx43", "nbg1"))
+
+	if unresolved := scan(t, c); len(unresolved) != 1 {
+		t.Errorf("expected the zero-priced node flagged, got %v", unresolved)
+	}
+}
+
+// Control-plane and other unmanaged nodes are not Karpenter's to price.
+func TestReconcile_IgnoresNodesKarpenterDoesNotOwn(t *testing.T) {
+	n := node("master", "cx43", "nbg1-dc3")
+	delete(n.Labels, karpv1.NodePoolLabelKey)
+	c := newTestController(nbg1Catalogue(), n)
+
+	if unresolved := scan(t, c); len(unresolved) != 0 {
+		t.Errorf("flagged a node Karpenter does not own: %v", unresolved)
+	}
+}
+
+// Until registration completes Karpenter prices from the NodeClaim's labels, and
+// the Node's zone label is written by that same registration. Counting nodes
+// mid-handshake would hold the gauge permanently non-zero on a scaling cluster
+// and make the alert worthless.
+func TestReconcile_IgnoresUnregisteredNode(t *testing.T) {
+	n := node("worker", "cx43", "")
+	delete(n.Labels, corev1.LabelTopologyZone)
+	delete(n.Labels, karpv1.NodeRegisteredLabelKey)
+	c := newTestController(nbg1Catalogue(), n)
+
+	if unresolved := scan(t, c); len(unresolved) != 0 {
+		t.Errorf("flagged a node that has not finished registering: %v", unresolved)
+	}
+}
+
+// A second Karpenter provider in the same cluster also labels its nodes with
+// karpenter.sh/nodepool. Those nodes are not ours to price, and flagging them
+// would alarm permanently on something this operator cannot fix.
+func TestReconcile_IgnoresAnotherProvidersNodePool(t *testing.T) {
+	foreignPool := &karpv1.NodePool{ObjectMeta: metav1.ObjectMeta{Name: "foreign"}}
+	foreignPool.Spec.Template.Spec.NodeClassRef = &karpv1.NodeClassReference{
+		Group: "karpenter.k8s.aws", Kind: "EC2NodeClass", Name: "default",
+	}
+	n := node("worker", "cx43", "us-east-1a")
+	n.Labels[karpv1.NodePoolLabelKey] = "foreign"
+
+	c := NewController(
+		newFakeClient(nodePool(testNodePool), foreignPool, n),
+		&fakeCatalogue{byNodePool: nbg1Catalogue()},
+	)
+
+	if unresolved := scan(t, c); len(unresolved) != 0 {
+		t.Errorf("flagged a node belonging to another provider: %v", unresolved)
+	}
+}
+
+// Failing to read the catalogue must not be reported as "everything is fine".
+// The gauge cannot carry that on its own -- it reads zero from process start, so
+// "no broken nodes" and "never managed to look" are the same number -- so the
+// scan counter is what has to move.
+func TestReconcile_CatalogueErrorDoesNotReportHealthy(t *testing.T) {
+	c := NewController(
+		newFakeClient(nodePool(testNodePool), node("worker", "cx43", "nbg1-dc3")),
+		&fakeCatalogue{err: fmt.Errorf("hcloud unavailable")},
+	)
+
+	before := metricValue(t, "karpenter_hetzner_price_health_scan_total")
+	if _, err := c.Reconcile(context.Background()); err != nil {
+		t.Fatalf("a catalogue failure must not fail the sweep: %v", err)
+	}
+	if after := metricValue(t, "karpenter_hetzner_price_health_scan_total"); after <= before {
+		t.Error("a failed scan left no trace on karpenter_hetzner_price_health_scan_total")
+	}
+}
+
+// The gauge is the deliverable: README tells operators to watch it. Publish it on
+// every successful scan, including zero, so it falls back to healthy once the
+// cause is fixed rather than latching at its worst value.
+func TestReconcile_PublishesTheUnresolvedCount(t *testing.T) {
+	c := newTestController(nbg1Catalogue(), node("bad", "cx43", "nbg1-dc3"))
+	if _, err := c.Reconcile(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := metricValue(t, "karpenter_hetzner_nodes_price_unresolved"); got != 1 {
+		t.Errorf("gauge = %v, want 1", got)
+	}
+
+	healthy := newTestController(nbg1Catalogue(), node("good", "cx43", "nbg1"))
+	if _, err := healthy.Reconcile(context.Background()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := metricValue(t, "karpenter_hetzner_nodes_price_unresolved"); got != 0 {
+		t.Errorf("gauge = %v after the cause was fixed, want 0", got)
+	}
+}
+
+// The whole value of this controller is that the log names the cause. The logger
+// encodes arbitrary values by reflection and never consults fmt.Stringer, so
+// unexported fields would render as "nodes":[{}] -- a line that looks
+// informative and carries nothing, with no test failing to say so.
+func TestReconcile_UnpricedNodesRenderInLogOutput(t *testing.T) {
+	var buf bytes.Buffer
+	core := zapcore.NewCore(
+		zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()),
+		zapcore.AddSync(&buf), zapcore.DebugLevel)
+	ctx := logf.IntoContext(context.Background(), zapr.NewLogger(zap.New(core)))
+
+	c := newTestController(nbg1Catalogue(), node("worker-abc", "cx43", "nbg1-dc3"))
+	if _, err := c.Reconcile(ctx); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, want := range []string{"worker-abc", "cx43", "nbg1-dc3", "on-demand"} {
+		if !bytes.Contains(buf.Bytes(), []byte(want)) {
+			t.Errorf("log output does not name %q; got %s", want, buf.String())
+		}
+	}
+}
+
+// The headline cause is the default CCM configuration, which misses on every node
+// at once -- so the common case is a fleet-sized list. An uncapped line is the one
+// most likely to be truncated or dropped by a log pipeline, losing the examples
+// that name the cause.
+func TestReconcile_CapsTheNodesItNames(t *testing.T) {
+	nodes := make([]client.Object, 0, maxLoggedNodes+5)
+	for i := range maxLoggedNodes + 5 {
+		nodes = append(nodes, node(fmt.Sprintf("worker-%d", i), "cx43", "nbg1-dc3"))
+	}
+
+	var buf bytes.Buffer
+	core := zapcore.NewCore(
+		zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()),
+		zapcore.AddSync(&buf), zapcore.DebugLevel)
+	ctx := logf.IntoContext(context.Background(), zapr.NewLogger(zap.New(core)))
+
+	c := newTestController(nbg1Catalogue(), nodes...)
+	if _, err := c.Reconcile(ctx); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := bytes.Count(buf.Bytes(), []byte(`"instanceType"`)); got != maxLoggedNodes {
+		t.Errorf("named %d nodes, want the cap of %d", got, maxLoggedNodes)
+	}
+	// The count stays exact even though the list is a sample.
+	if !bytes.Contains(buf.Bytes(), []byte(`"count":15`)) {
+		t.Errorf("log does not carry the full count; got %s", buf.String())
+	}
+}
+
+func TestReconcile_KeepsCadenceOnError(t *testing.T) {
+	c := NewController(newFakeClient(), &fakeCatalogue{err: fmt.Errorf("hcloud unavailable")})
+
+	res, err := c.Reconcile(context.Background())
+	if err != nil {
+		t.Fatalf("a catalogue failure must not fail the sweep: %v", err)
+	}
+	if res.RequeueAfter != resyncInterval {
+		t.Errorf("expected the sweep to keep its cadence, got %v", res.RequeueAfter)
+	}
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -45,6 +45,27 @@ var (
 		Help:      "Total number of Hetzner server delete calls by result.",
 	}, []string{"result"})
 
+	// nodesPriceUnresolved reports how many Karpenter-owned nodes currently price
+	// at zero, because their zone and capacity-type match no offering of their
+	// instance type. Karpenter cannot consolidate a node it prices at zero:
+	// nothing is cheaper, so every replacement is rejected and the decision reads
+	// as a considered "Can't replace with a cheaper node". A gauge, not a counter,
+	// because the question is how many are broken right now.
+	nodesPriceUnresolved = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: "karpenter_hetzner",
+		Name:      "nodes_price_unresolved",
+		Help:      "Karpenter-owned nodes whose price does not resolve to any offering, disabling consolidation for them.",
+	})
+
+	// priceHealthScanTotal counts scans by result. A gauge reads zero from process
+	// start, so "no broken nodes" and "the check has never managed to run" are the
+	// same number; only a rising success count says the zero is real.
+	priceHealthScanTotal = prometheus.NewCounterVec(prometheus.CounterOpts{
+		Namespace: "karpenter_hetzner",
+		Name:      "price_health_scan_total",
+		Help:      "Outcomes of the node price-resolution scan.",
+	}, []string{"result"})
+
 	// hcloudAPICallsTotal counts hcloud API calls by operation and result. We
 	// scope it to the operations we actually instrument (server_create,
 	// server_delete, placement_group, image_list) to keep label cardinality
@@ -78,7 +99,21 @@ func init() {
 		hcloudAPICallsTotal,
 		driftDetectedTotal,
 		instanceTypeCacheTotal,
+		nodesPriceUnresolved,
+		priceHealthScanTotal,
 	)
+}
+
+// SetNodesPriceUnresolved records how many nodes currently fail price
+// resolution. Call it on every successful scan, including with zero, so the
+// gauge falls back to healthy once the cause is fixed.
+func SetNodesPriceUnresolved(n int) {
+	nodesPriceUnresolved.Set(float64(n))
+}
+
+// RecordPriceHealthScan records whether a price-resolution scan completed.
+func RecordPriceHealthScan(result string) {
+	priceHealthScanTotal.WithLabelValues(result).Inc()
 }
 
 // RecordServerCreate records a server create result and its duration.


### PR DESCRIPTION
Karpenter prices a running node by looking its zone and capacity-type up against its instance type's offerings. A miss returns zero — and **nothing is cheaper than zero**, so every candidate replacement is rejected and the decision is logged as `Unconsolidatable: "Can't replace with a cheaper node"`.

That message is indistinguishable from a considered decision, which is what makes this hard to notice. Consolidation is simply off for the affected nodes, indefinitely.

## Why it is silent

`karpenter_nodepools_cost_total` keeps reporting correctly throughout, because it resolves the price from the **NodeClaim's** labels rather than the **Node's**. Spend looks right while rightsizing is dead. The only reliable tell is the pair:

```
karpenter_nodepools_cost_total   -> non-zero and correct
every disruption decision        -> savings: $0.00
```

## The common cause on this provider

Offerings are keyed on the Hetzner **location** (`nbg1`), but `hcloud-cloud-controller-manager` labels nodes with the legacy **datacenter** (`nbg1-dc3`) by default. The lookup misses and the node prices at zero.

Setting `HCLOUD_INSTANCES_ZONE_LABEL_ENABLED=false` on the CCM fixes it, since Karpenter's registration then fills the label from the NodeClaim. But that is cluster-wide, so any node Karpenter does *not* register ends up with **no** zone label at all — which fails to price for the same reason and does not go away when Hetzner removes datacenters from the API on 2026-10-01.

## What this adds

A small read-only controller that runs the same lookup Karpenter runs, over every registered Karpenter-owned node, and exports `karpenter_hetzner_nodes_price_unresolved`.

It is deliberately **not** a check for datacenter-shaped zone labels. Running the real lookup cannot drift from the real failure, and it catches every cause: the legacy label, the missing label, an instance type absent from the catalogue, a location dropped from the NodeClass.

## Two details worth a reviewer's attention

**The catalogue is fetched per NodePool**, via `CloudProvider.GetInstanceTypes`, not globally — because that is what core prices against, and it filters to the NodeClass's `locations`. A catalogue-wide lookup would resolve offerings core has filtered away and report healthy during exactly the outage this detects. Narrowing a NodeClass's locations with nodes still running outside them is the case that exposed this.

**A registered gauge reads zero from process start**, so a scan that never ran is indistinguishable from a healthy fleet — a revoked token would serve "zero unresolved" indefinitely. `karpenter_hetzner_price_health_scan_total` separates the two, and for the same reason a failed scan leaves the gauge untouched rather than zeroing it.

## Scope

Additive only: one new package, two metrics, one wiring line, one README section. No behaviour change to provisioning, disruption or the CloudProvider surface, and nothing is deleted or mutated.

Tests cover the datacenter-labelled node, the label-less node, an unknown instance type, a zero-priced offering, a node outside its NodePool's catalogue, nodes Karpenter does not own, other providers' NodePools, unregistered nodes, and the scan-failure path. The log output is asserted against a real zap encoder, since the fields are only useful if they actually render.

Split out of a larger branch that also reclaims orphaned servers; the two address unrelated failures and this one is read-only, so it seemed wrong to hold it behind a controller that deletes machines.
