### PR TITLE
fix: wait for volumes to detach before deleting a server

### DIFF
--- a/pkg/cloudprovider/cloudprovider.go
+++ b/pkg/cloudprovider/cloudprovider.go
@@ -210,9 +210,78 @@ func (cp *CloudProvider) Create(ctx context.Context, nodeClaim *karpv1.NodeClaim
 	return created, nil
 }
 
+// VolumeDetachmentTimeout bounds how long Delete will hold off destroying a
+// server that still has volumes attached.
+//
+// Deleting a server force-detaches whatever is attached to it, so an unbounded
+// wait would turn a stuck detach into a node that can never terminate -- strictly
+// worse than the unclean detach it is trying to avoid. Past this point we delete
+// anyway, which is exactly the behaviour that existed before this check, so the
+// worst case is today's behaviour rather than a wedged node.
+//
+// Karpenter core has already waited for the Kubernetes VolumeAttachment to be
+// removed by the time Delete is called, so the remaining hcloud-side detach
+// should be seconds. Five minutes is generous for that, and short enough not to
+// meaningfully delay a rolling consolidation.
+const VolumeDetachmentTimeout = 5 * time.Minute
+
 // Delete terminates the server backing the given NodeClaim.
+//
+// A server whose volumes are still attached is left alone and nil is returned:
+// in core's termination contract a nil error means "still terminating", and core
+// requeues after 5s. Only a NodeClaimNotFoundError ends that loop.
 func (cp *CloudProvider) Delete(ctx context.Context, nodeClaim *karpv1.NodeClaim) error {
+	if cp.awaitingVolumeDetachment(ctx, nodeClaim) {
+		return nil
+	}
 	return cp.instanceProvider.Delete(ctx, nodeClaim.Status.ProviderID)
+}
+
+// awaitingVolumeDetachment reports whether the server still has volumes attached
+// and is still within the detachment grace.
+//
+// Karpenter core waits for the Kubernetes VolumeAttachment object to disappear
+// before it calls Delete, but that object is removed by the attach-detach
+// controller and its removal does not prove hcloud has finished detaching. The
+// gap between the two is enough to destroy a server with a live filesystem on it,
+// which leaves the volume needing recovery and, on reattach, can wedge the mount
+// in the kernel.
+//
+// This deliberately lives here rather than in the instance provider. The orphan
+// server sweep deletes through that provider too, and an orphan whose volume is
+// stuck must stay reclaimable -- otherwise it bills indefinitely, which is the
+// failure that sweep exists to prevent.
+//
+// Every uncertain path returns false (proceed with the delete). A check that
+// cannot answer must not be able to block termination.
+func (cp *CloudProvider) awaitingVolumeDetachment(ctx context.Context, nodeClaim *karpv1.NodeClaim) bool {
+	// Without a deletion timestamp there is no clock to bound the wait against,
+	// so waiting could never end. Behave as if the check were not here.
+	if nodeClaim.DeletionTimestamp == nil {
+		return false
+	}
+	if time.Since(nodeClaim.DeletionTimestamp.Time) >= VolumeDetachmentTimeout {
+		logf.FromContext(ctx).Info("deleting server with volumes still attached: detachment grace elapsed",
+			"providerID", nodeClaim.Status.ProviderID,
+			"grace", VolumeDetachmentTimeout.String())
+		return false
+	}
+
+	// A server we cannot read is not a server we can make claims about. Fall
+	// through so Delete reports whatever the real state is, including the
+	// NodeClaimNotFoundError that tells core termination has finished.
+	server, err := cp.instanceProvider.Get(ctx, nodeClaim.Status.ProviderID)
+	if err != nil || server == nil {
+		return false
+	}
+	if len(server.Volumes) == 0 {
+		return false
+	}
+
+	logf.FromContext(ctx).Info("waiting for volumes to detach before deleting server",
+		"providerID", nodeClaim.Status.ProviderID,
+		"volumes", len(server.Volumes))
+	return true
 }
 
 // Get retrieves the NodeClaim corresponding to the given provider ID.

--- a/pkg/cloudprovider/volumedetach_test.go
+++ b/pkg/cloudprovider/volumedetach_test.go
@@ -1,0 +1,127 @@
+package cloudprovider_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	karpv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+
+	apiv1 "github.com/paperclipinc/karpenter-provider-hetzner/pkg/apis/v1"
+	"github.com/paperclipinc/karpenter-provider-hetzner/pkg/cloudprovider"
+	"github.com/paperclipinc/karpenter-provider-hetzner/pkg/providers/imagefamily"
+	"github.com/paperclipinc/karpenter-provider-hetzner/pkg/providers/instance"
+	"github.com/paperclipinc/karpenter-provider-hetzner/pkg/providers/instancetype"
+)
+
+// buildDeleteCP wires a CloudProvider around one server and returns the fake so
+// the test can see whether the server was actually destroyed.
+func buildDeleteCP(t *testing.T, server *hcloud.Server) (*cloudprovider.CloudProvider, *fakeServerClient) {
+	t.Helper()
+	_ = apiv1.SchemeBuilder.AddToScheme(scheme.Scheme)
+	nc := baselineNodeClass()
+	kube := fake.NewClientBuilder().WithScheme(scheme.Scheme).WithObjects(nc).Build()
+	fsc := &fakeServerClient{servers: map[int64]*hcloud.Server{server.ID: server}}
+	cp := cloudprovider.NewCloudProvider(kube,
+		instance.NewProvider(fsc, "test-cluster"),
+		instancetype.NewProvider(&fakeServerTypeClient{}),
+		imagefamily.NewProvider(&fakeImageClient{}))
+	return cp, fsc
+}
+
+// terminatingClaim is a NodeClaim that core is driving through termination:
+// deleted `age` ago, pointing at the given server.
+func terminatingClaim(serverID int64, age time.Duration) *karpv1.NodeClaim {
+	deleted := metav1.NewTime(time.Now().Add(-age))
+	return &karpv1.NodeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "claim", DeletionTimestamp: &deleted},
+		Status:     karpv1.NodeClaimStatus{ProviderID: instance.FormatProviderID(serverID)},
+	}
+}
+
+func serverWithVolumes(id int64, volumes ...int64) *hcloud.Server {
+	s := &hcloud.Server{ID: id, ServerType: &hcloud.ServerType{Name: "cx22"}}
+	for _, v := range volumes {
+		s.Volumes = append(s.Volumes, &hcloud.Volume{ID: v})
+	}
+	return s
+}
+
+// TestDelete_WaitsWhileVolumeStillAttached is the regression for the unclean
+// detach: destroying a server while hcloud still has a volume attached tears a
+// live filesystem away mid-write.
+//
+// Karpenter core already waits for the Kubernetes VolumeAttachment to be
+// removed, but that object disappearing does not prove hcloud has finished
+// detaching. Returning nil here means "still terminating" in core's contract, so
+// core requeues in 5s rather than treating the node as gone.
+func TestDelete_WaitsWhileVolumeStillAttached(t *testing.T) {
+	server := serverWithVolumes(50, 106145787)
+	cp, fsc := buildDeleteCP(t, server)
+
+	if err := cp.Delete(context.Background(), terminatingClaim(50, 30*time.Second)); err != nil {
+		t.Fatalf("expected no error while awaiting detachment, got %v", err)
+	}
+	if _, ok := fsc.servers[50]; !ok {
+		t.Error("server was destroyed while a volume was still attached")
+	}
+}
+
+// A server with nothing attached must not be delayed at all.
+func TestDelete_ProceedsWhenNoVolumesAttached(t *testing.T) {
+	cp, fsc := buildDeleteCP(t, serverWithVolumes(50))
+
+	if err := cp.Delete(context.Background(), terminatingClaim(50, time.Second)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := fsc.servers[50]; ok {
+		t.Error("server with no attached volumes should have been deleted immediately")
+	}
+}
+
+// The wait has to be bounded. A detach that never completes would otherwise
+// leave a node that can never terminate; past the bound we delete anyway, since
+// destroying the server force-detaches. That degrades to today's behaviour, not
+// worse than it.
+func TestDelete_ProceedsOnceGraceElapsed(t *testing.T) {
+	cp, fsc := buildDeleteCP(t, serverWithVolumes(50, 106145787))
+
+	if err := cp.Delete(context.Background(), terminatingClaim(50, time.Hour)); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := fsc.servers[50]; ok {
+		t.Error("server should have been deleted once the detachment grace elapsed")
+	}
+}
+
+// Without a DeletionTimestamp there is no clock to bound the wait against, so
+// waiting could never end. Fail open: behave exactly as before this change.
+func TestDelete_ProceedsWhenClaimHasNoDeletionTimestamp(t *testing.T) {
+	cp, fsc := buildDeleteCP(t, serverWithVolumes(50, 106145787))
+
+	claim := &karpv1.NodeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "claim"},
+		Status:     karpv1.NodeClaimStatus{ProviderID: instance.FormatProviderID(50)},
+	}
+	if err := cp.Delete(context.Background(), claim); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := fsc.servers[50]; ok {
+		t.Error("server should have been deleted when the claim carries no deletion timestamp")
+	}
+}
+
+// An already-gone server must still report NodeClaimNotFound, which is how core
+// knows termination finished. The volume check must not swallow that.
+func TestDelete_MissingServerStillReportsNotFound(t *testing.T) {
+	cp, _ := buildDeleteCP(t, serverWithVolumes(50))
+
+	err := cp.Delete(context.Background(), terminatingClaim(999, time.Second))
+	if err == nil {
+		t.Fatal("expected a NodeClaimNotFound error for a server that no longer exists")
+	}
+}


### PR DESCRIPTION
Deleting a Hetzner server force-detaches whatever is attached to it. If a detach is already in flight when that happens, the filesystem is torn away mid-write — and the volume can come back in a state where the *mount* hangs in the kernel, uninterruptibly, on every retry:

```
mount -> ext4_fill_super -> ext4_init_orphan_info -> ext4_bread -> __wait_on_buffer   [D state]
```

Not on-disk corruption — the same filesystem mounts in seconds on a different node, journal replay completes, no `e2fsck` needed. But the node that first tried to mount it accumulates one D-state `mount` per kubelet retry and can never mount that volume again.

`Delete` currently issues the server delete without ever looking at `server.Volumes`.

## What this looks like in practice

From the CSI driver logs of an incident that cost 73 minutes of a replicated store being down to one replica:

```
08:02:54  node tainted for disruption
08:02:58  unpublishing volume            (unmount from the pod)
08:03:04  detaching volume from server   (five volumes at once from this node)
          ... no detach completion is ever logged for the affected volume ...
08:03:24  provider deletes the server    <- 20s after the detach began
08:04:20  attaching volume               (to the replacement server)
08:04:35  failed to attach volume / failed to get volume
08:04:37  publishing volume              <- the D-state mount begins here
```

Sibling volumes on the same node *did* log `"volume not attached to a server"` at 08:03:20 — clean detaches. The affected one never did. Three others failed outright with `"failed to detach volume" err="context canceled"`, and their retries hit `"cannot perform operation because server is locked"` — the lock being the deletion already in progress.

So the volume was still attached, with a detach outstanding, when the server was destroyed underneath it.

## Why Karpenter core does not already prevent this

It very nearly does. `pkg/controllers/node/termination` runs `awaitDrain`, then `awaitVolumeDetachment`, then `awaitInstanceTermination`, and `cloudProvider.Delete` is only reached from the third. So the provider is normally called on a node whose volumes are already gone.

The gap is what "detached" means. Core waits for the Kubernetes `VolumeAttachment` object to disappear, which is the attach-detach controller's view. That is not the same fact as the cloud provider having finished.

I measured the ordering on a synthetic consolidation — a throwaway PVC with a dirty ext4, pod deleted, polling both sides once a second:

```
t=13.90  hcloud volume DETACHED
t=17.08  VolumeAttachment GONE (k8s believes detached)
```

On the happy path Hetzner finishes **~3s before** Kubernetes removes the attachment, so by the time `Delete` is called there is nothing attached and this change does nothing at all. It is only when a detach stalls or fails — as above — that the two diverge and the provider gets called on a server that still has volumes.

That measurement is worth stating plainly because it sets the cost: **inert in normal operation, active only on the failure path.**

## The change

`Delete` reads the server first and, if `server.Volumes` is non-empty, returns without deleting.

Core's contract makes that sufficient by itself. In `awaitInstanceTermination` a `nil` error means *"still terminating"* and core requeues after 5s; only `NodeClaimNotFoundError` ends the loop. So the provider declines until it is safe and core does the polling — no core change, no new RBAC, no extra controller.

## Three decisions worth a reviewer's attention

**It is bounded.** An unbounded wait turns a stuck detach into a node that can never terminate, holding its volume, its capacity and its bill — worse than the unclean detach it set out to prevent. Past the grace we delete anyway, which is exactly the behaviour that exists today, so the worst case is the status quo rather than a wedged node.

**The grace comes from `nodeClaim.DeletionTimestamp`**, not an in-process timer, so an operator restart mid-termination does not silently reset the clock and start the wait over.

**It is not in the instance provider.** Both delete paths funnel through `instance.Provider.Delete`, and the other caller is the orphaned-server sweep. An orphan whose volume is stuck must stay reclaimable — blocking it strands a billing server indefinitely, which is the precise failure that sweep exists to prevent. The wait therefore lives at the `CloudProvider` layer, which is also the only layer holding the NodeClaim the grace is measured against.

## Failure behaviour

Every uncertain path proceeds with the delete rather than waiting: a nil deletion timestamp (no clock to bound against), a server that cannot be read, a server already gone. A check that cannot answer must not be able to block termination — and an unreadable server must still surface `NodeClaimNotFoundError`, or core never learns termination finished.

## On the five minutes

Core has already waited for the Kubernetes attachment by the time `Delete` is called, so the remaining provider-side detach should be seconds; in the incident above the driver was still retrying a minute later. Five minutes is generous for the first and bounded well short of the second. Left as a constant rather than another configuration knob until there is evidence one is wanted — happy to promote it to an operator option.

## Tests

Written RED-first, and each guard mutation-tested: reverting any one makes exactly its test fail. The nil-timestamp check is the interesting one — removing it is a nil dereference rather than a wrong answer, so it is load-bearing for a different reason than the others.

Covered: volume still attached (waits), no volumes (deletes immediately), grace elapsed (deletes anyway), no deletion timestamp (deletes), missing server (still reports `NodeClaimNotFound`). The two pre-existing delete tests pass unchanged.

## What this does not fix

It does not stop a detach from stalling, and it is not a substitute for finding out why five simultaneous detaches stalled with attaches to the replacement nodes racing them, or what cancelled three of them — `context canceled` on a `ControllerUnpublish` means the caller gave up, and that is in the CSI layer, not here.

What it does is stop this provider from turning a slow or failed detach into a destroyed filesystem.
