### PR TITLE
chore(release): v2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.1.1] - 2026-08-26
+
+### Fixed
+- Chart RBAC grants event `create`/`patch` on the `events.k8s.io` API group alongside the legacy core group. The nodeclass controller records events through controller-runtime's `GetEventRecorder`, which writes `events.k8s.io` Events, so the controller logged `events.events.k8s.io is forbidden` on every event it tried to emit. The core `""` group is kept because karpenter core still uses the legacy recorder (#52).
+
+### Security
+- Go toolchain bumped to 1.26.7 (from 1.26.5), clearing five stdlib vulnerabilities flagged by govulncheck (GO-2026-6218, GO-2026-6090, GO-2026-6089, GO-2026-5972, GO-2026-5026; all fixed by 1.26.6). The release image builder is pinned to `golang:1.26.7-alpine` so the shipped binary is built with the same toolchain CI tests with. Local builds now require Go >= 1.26.7 (#57).
+
 ### Changed
-- Go toolchain bumped to 1.26.7 (from 1.26.5), clearing five stdlib vulnerabilities flagged by govulncheck (GO-2026-6218, GO-2026-6090, GO-2026-6089, GO-2026-5972, GO-2026-5026; all fixed by 1.26.6). The release image builder is pinned to `golang:1.26.7-alpine` so the shipped binary is built with the same toolchain CI tests with. Local builds now require Go >= 1.26.7.
-- `make vendor-core-crds` downloads the `sigs.k8s.io/karpenter` module before resolving its directory, fixing `generate` CI failures on any PR that changes `go.mod`/`go.sum` (cold module cache made `go list -m` return an empty dir).
+- `make vendor-core-crds` downloads the `sigs.k8s.io/karpenter` module before resolving its directory, fixing `generate` CI failures on any PR that changes `go.mod`/`go.sum` (cold module cache made `go list -m` return an empty dir) (#57).
+
+### Changed (dependencies)
+- Bumped `sigs.k8s.io/karpenter` to 1.14.1, `hetznercloud/hcloud-go` to 2.47.0, and `k8s.io/{api,apimachinery,client-go}` to 0.36.4 (#58).
 
 ## [2.1.0] - 2026-08-01
 
@@ -90,7 +100,8 @@ detection, observability, supply-chain attestations, and adoption docs.
 - Grant full Karpenter-core RBAC in Helm chart (#13).
 - Treat `unsupported location for server type` as an unavailable offering rather than a hard error (#16).
 
-[Unreleased]: https://github.com/paperclipinc/karpenter-provider-hetzner/compare/v2.1.0...HEAD
+[Unreleased]: https://github.com/paperclipinc/karpenter-provider-hetzner/compare/v2.1.1...HEAD
+[2.1.1]: https://github.com/paperclipinc/karpenter-provider-hetzner/compare/v2.1.0...v2.1.1
 [2.1.0]: https://github.com/paperclipinc/karpenter-provider-hetzner/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/paperclipinc/karpenter-provider-hetzner/compare/v1.0.0...v2.0.0
 [1.0.0]: https://github.com/paperclipinc/karpenter-provider-hetzner/compare/v0.3.0...v1.0.0

--- a/charts/karpenter-provider-hetzner/Chart.yaml
+++ b/charts/karpenter-provider-hetzner/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: karpenter-provider-hetzner
 description: Karpenter cloud provider for Hetzner Cloud
 type: application
-version: 2.1.0
-appVersion: "2.1.0"
+version: 2.1.1
+appVersion: "2.1.1"
 # home points at Paperclip.inc (the project's canonical page) so listing
 # "Homepage" links drive backlinks to the domain; GitHub stays as source.
 home: https://paperclip.inc/karpenter-hetzner
@@ -29,9 +29,11 @@ annotations:
     - name: k3s bootstrap guide
       url: https://github.com/paperclipinc/karpenter-provider-hetzner/blob/main/docs/k3s-bootstrap.md
   artifacthub.io/category: integration-delivery
-  artifacthub.io/containsSecurityUpdates: "false"
+  artifacthub.io/containsSecurityUpdates: "true"
   artifacthub.io/changes: |
     - kind: fixed
-      description: "Pods bound to an hcloud CSI volume can now trigger provisioning: csi.hetzner.cloud/location is aliased to topology.kubernetes.io/zone"
-    - kind: added
-      description: "Expose nodeSelector, affinity, tolerations, topologySpreadConstraints, imagePullSecrets, priorityClassName, command, args and an optional PodDisruptionBudget (minAvailable or maxUnavailable) on the Deployment via chart values"
+      description: "RBAC grants event create/patch on events.k8s.io alongside the legacy core group, so the controller can emit events through the modern recorder"
+    - kind: security
+      description: "Operator image rebuilt with Go 1.26.7, clearing five stdlib vulnerabilities (GO-2026-6218, GO-2026-6090, GO-2026-6089, GO-2026-5972, GO-2026-5026)"
+    - kind: changed
+      description: "Dependency bumps: sigs.k8s.io/karpenter 1.14.1, hcloud-go 2.47.0, k8s.io libraries 0.36.4"


### PR DESCRIPTION
Release chore for v2.1.1: move `[Unreleased]` to `[2.1.1]`, bump the chart to 2.1.1, and refresh the Artifact Hub annotations (`containsSecurityUpdates: true` for the Go 1.26.7 stdlib CVE rebuild).

Contents of the release:
- **Fixed:** chart RBAC grants events on `events.k8s.io` so the controller can emit events through the modern recorder (#52)
- **Security:** operator image rebuilt with Go 1.26.7, clearing GO-2026-6218, GO-2026-6090, GO-2026-6089, GO-2026-5972, GO-2026-5026 (#57)
- **Changed:** `vendor-core-crds` module-download fix (#57); karpenter 1.14.1, hcloud-go 2.47.0, k8s.io 0.36.4 (#58)

After merge: tag `v2.1.1` on the merge commit to trigger the Release workflow (image + chart + signatures), then publish the release page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FJnTGiMuTJSFUVRRqjfTbV