### PR TITLE
chore(release): v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.0] - 2026-09-02
+
 ### Changed
 - Server type selection now launches the cheapest compatible offering instead of the first type the hcloud API happened to return. Karpenter core already ranks the instance types it sends by price; the provider iterated them in hcloud's own order (ascending server-type id), which puts the pricier CPX family ahead of CX and could buy a type several times the cost of an identically sized alternative. Selection and launch now derive from a single offering, so the location a server is created in — and the `topology.kubernetes.io/zone` label stamped on the node — always match the offering whose price it was ranked on (#50).
 - **Check your NodePools before upgrading.** A NodePool that does not constrain `kubernetes.io/arch` may now get arm64 (CAX) nodes wherever an ARM offering prices below the amd64 ones it permits — the old hcloud-id ordering produced amd64 incidentally, not by policy. Pods with amd64-only images and no arch `nodeSelector` fail on such nodes with `exec format error`. Pin `kubernetes.io/arch: [amd64]` on those NodePools to keep the previous behaviour. The architecture remains the pool's choice, not the provider's: Karpenter core decides which instance types are eligible for the pending pods, and the provider launches the cheapest of the ones core sent (#50).
@@ -115,7 +117,8 @@ detection, observability, supply-chain attestations, and adoption docs.
 - Grant full Karpenter-core RBAC in Helm chart (#13).
 - Treat `unsupported location for server type` as an unavailable offering rather than a hard error (#16).
 
-[Unreleased]: https://github.com/paperclipinc/karpenter-provider-hetzner/compare/v2.1.1...HEAD
+[Unreleased]: https://github.com/paperclipinc/karpenter-provider-hetzner/compare/v2.2.0...HEAD
+[2.2.0]: https://github.com/paperclipinc/karpenter-provider-hetzner/compare/v2.1.1...v2.2.0
 [2.1.1]: https://github.com/paperclipinc/karpenter-provider-hetzner/compare/v2.1.0...v2.1.1
 [2.1.0]: https://github.com/paperclipinc/karpenter-provider-hetzner/compare/v2.0.0...v2.1.0
 [2.0.0]: https://github.com/paperclipinc/karpenter-provider-hetzner/compare/v1.0.0...v2.0.0

--- a/charts/karpenter-provider-hetzner/Chart.yaml
+++ b/charts/karpenter-provider-hetzner/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: karpenter-provider-hetzner
 description: Karpenter cloud provider for Hetzner Cloud
 type: application
-version: 2.1.1
-appVersion: "2.1.1"
+version: 2.2.0
+appVersion: "2.2.0"
 # home points at Paperclip.inc (the project's canonical page) so listing
 # "Homepage" links drive backlinks to the domain; GitHub stays as source.
 home: https://paperclip.inc/karpenter-hetzner
@@ -29,11 +29,17 @@ annotations:
     - name: k3s bootstrap guide
       url: https://github.com/paperclipinc/karpenter-provider-hetzner/blob/main/docs/k3s-bootstrap.md
   artifacthub.io/category: integration-delivery
-  artifacthub.io/containsSecurityUpdates: "true"
+  artifacthub.io/containsSecurityUpdates: "false"
   artifacthub.io/changes: |
-    - kind: fixed
-      description: "RBAC grants event create/patch on events.k8s.io alongside the legacy core group, so the controller can emit events through the modern recorder"
-    - kind: security
-      description: "Operator image rebuilt with Go 1.26.7, clearing five stdlib vulnerabilities (GO-2026-6218, GO-2026-6090, GO-2026-6089, GO-2026-5972, GO-2026-5026)"
     - kind: changed
-      description: "Dependency bumps: sigs.k8s.io/karpenter 1.14.1, hcloud-go 2.47.0, k8s.io libraries 0.36.4"
+      description: "Instance-type selection is cheapest-first: Create launches the cheapest compatible offering and in that offering's location, instead of the first type the hcloud API returned (which bought CPX where CX fit at 3-4x the price)"
+    - kind: changed
+      description: "NodePools that do not constrain kubernetes.io/arch may now receive arm64 (CAX) nodes where they price lower; pin kubernetes.io/arch to amd64 to keep the previous behaviour"
+    - kind: fixed
+      description: "Create no longer dead-ends on an instance type whose architecture the HCloudNodeClass has no image for; such types are skipped and advertised unavailable, and a total miss reports NodeClassNotReady instead of InsufficientCapacity"
+    - kind: fixed
+      description: "Image resolution distinguishes a missing image from an unreadable catalogue; transient hcloud errors keep the last resolved image instead of clearing status, and wrong-architecture images are rejected before being recorded"
+    - kind: fixed
+      description: "Unpriced offerings are marked unavailable rather than priced at zero, and price ties break deterministically on type name"
+    - kind: added
+      description: "Metrics karpenter_hetzner_image_resolution_errors_total and karpenter_hetzner_instance_type_selection_skipped_total{arch,reason}"


### PR DESCRIPTION
Release chore for v2.2.0: move `[Unreleased]` to `[2.2.0]`, bump the chart to 2.2.0, and refresh the Artifact Hub annotations (`containsSecurityUpdates: false`; no security fixes in this release).

Minor bump rather than patch: the release changes default behaviour (cheapest-first selection, with the arm64 upgrade note) and adds two metrics.

Contents of the release, all from #50:
- **Changed:** instance-type selection is cheapest-first and launches into the offering it was ranked on, so the zone label always matches where the server is. **Upgrade note:** NodePools that leave `kubernetes.io/arch` unconstrained may now get arm64 (CAX) nodes where they price lower.
- **Fixed:** `Create` no longer dead-ends on an architecture the NodeClass has no image for; `GetInstanceTypes` advertises those types unavailable so core stops scheduling onto them; a total miss reports `NodeClassNotReady` instead of `InsufficientCapacity`.
- **Fixed:** image resolution distinguishes "no such image" from "catalogue unreadable"; transient errors keep the last resolved image and set `ImagesReady=Unknown`; status-sourced images are gated on the spec generation that produced them; wrong-arch images are rejected before being recorded.
- **Fixed:** unpriced offerings are marked unavailable instead of priced at zero; price ties break deterministically on type name.
- **Added:** `karpenter_hetzner_image_resolution_errors_total` and `karpenter_hetzner_instance_type_selection_skipped_total{arch,reason}`.

After merge: tag `v2.2.0` on the merge commit to trigger the Release workflow (image + chart + signatures), then publish the release page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017SsMgGhYofdC1ZgbKsYoER
