### PR TITLE
fix: bound every hcloud HTTP request with a timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- The hcloud API client now bounds every HTTP request. `hcloud.NewClient` defaults to a bare `&http.Client{}`, which has no `Timeout`, so a connection that is accepted and never answered — a blackholed route to `api.hetzner.cloud`, a middlebox that swallows the response, a stalled TLS handshake — parked the calling goroutine forever. Every caller is a controller-runtime worker and controller-runtime imposes no per-reconcile deadline, so each hung request permanently consumed a worker while the operator kept reporting healthy. The client now carries a 30s per-request timeout plus explicit dial, TLS-handshake and response-header bounds, which also turns a hang into a `net.Error` the SDK's existing retry policy already treats as retryable (#71).
+
+### Added
+- `HCLOUD_API_TIMEOUT` (chart: `hcloud.apiTimeout`, default `30s`, max `5m`) tunes that per-request timeout. It bounds a single HTTP request, not a whole operation: the SDK's action waiter polls `/actions` in a loop of separate requests, so a server create that legitimately takes minutes is many short requests. An unparseable or out-of-range value fails startup rather than silently falling back (#71).
+
 ## [2.2.0] - 2026-09-02
 
 ### Changed

--- a/charts/karpenter-provider-hetzner/README.md
+++ b/charts/karpenter-provider-hetzner/README.md
@@ -43,6 +43,7 @@ Existing `v1alpha1` objects are not migrated automatically; recreate them under
 | `image.pullPolicy` | `IfNotPresent` | Image pull policy |
 | `auth.secretRef.name` | `hcloud-token` | Secret holding the Hetzner token |
 | `auth.secretRef.key` | `token` | Key within the secret |
+| `hcloud.apiTimeout` | `30s` | Bounds a single hcloud HTTP request (Go duration, max `5m`). Per request, not per operation |
 | `serviceAccount.create` | `true` | Create the service account |
 | `serviceAccount.name` | `karpenter` | Service account name |
 | `metrics.port` | `8080` | Prometheus metrics port |

--- a/charts/karpenter-provider-hetzner/templates/deployment.yaml
+++ b/charts/karpenter-provider-hetzner/templates/deployment.yaml
@@ -68,6 +68,8 @@ spec:
                   key: {{ .Values.auth.secretRef.key }}
             - name: CLUSTER_NAME
               value: {{ .Values.clusterName | quote }}
+            - name: HCLOUD_API_TIMEOUT
+              value: {{ .Values.hcloud.apiTimeout | quote }}
             - name: METRICS_PORT
               value: {{ .Values.metrics.port | quote }}
             - name: HEALTH_PROBE_PORT

--- a/charts/karpenter-provider-hetzner/values.yaml
+++ b/charts/karpenter-provider-hetzner/values.yaml
@@ -13,6 +13,15 @@ auth:
     name: hcloud-token
     key: token
 
+hcloud:
+  # apiTimeout bounds a single hcloud HTTP request (Go duration, max 5m). It is
+  # per request, not per operation: the SDK polls actions in a loop of separate
+  # requests, so a server create that legitimately takes minutes is many short
+  # requests. Without it a blackholed connection to api.hetzner.cloud parks a
+  # controller worker forever. Raise it only if you see timeouts against a
+  # healthy API.
+  apiTimeout: 30s
+
 serviceAccount:
   create: true
   name: karpenter

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -25,16 +25,18 @@ import (
 func main() {
 	ctx, op := operator.NewOperator()
 
-	// Create the Hetzner Cloud API client.
-	hcloudClient, err := hetznerop.NewHCloudClient()
-	if err != nil {
-		log.FromContext(ctx).Error(err, "failed to create Hetzner Cloud client")
-		return
-	}
-
 	cfg, err := hetznerop.LoadConfig()
 	if err != nil {
 		log.FromContext(ctx).Error(err, "failed to load config")
+		return
+	}
+
+	// Create the Hetzner Cloud API client. Built from cfg so the API timeout is
+	// applied to the HTTP client the SDK is constructed with; it cannot be set
+	// afterwards.
+	hcloudClient, err := hetznerop.NewHCloudClient(cfg)
+	if err != nil {
+		log.FromContext(ctx).Error(err, "failed to create Hetzner Cloud client")
 		return
 	}
 

--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -5,19 +5,40 @@ import (
 	"os"
 	"regexp"
 	"strings"
+	"time"
 )
 
 var clusterNameRE = regexp.MustCompile(`^[a-zA-Z0-9._-]{1,63}$`)
+
+const (
+	// defaultAPITimeout bounds a single hcloud HTTP request. Hetzner's API
+	// answers healthy requests in well under a second; 30s is generous enough
+	// that a slow-but-working API is never mistaken for a hung one, and short
+	// enough that a blackholed connection frees the worker within one reconcile
+	// backoff rather than never.
+	defaultAPITimeout = 30 * time.Second
+
+	// maxAPITimeout caps what an operator may configure. A timeout is only useful
+	// while it is shorter than the patience of everything above it; past a few
+	// minutes it stops bounding anything and just reintroduces the hang it exists
+	// to prevent.
+	maxAPITimeout = 5 * time.Minute
+)
 
 // Config holds provider configuration sourced from the environment.
 type Config struct {
 	// ClusterName scopes all managed servers so multiple clusters can share
 	// one Hetzner project without colliding.
 	ClusterName string
+
+	// APITimeout bounds a single hcloud HTTP request. It is per request, not per
+	// operation: the SDK's action waiter polls in a loop of separate requests, so
+	// a create that legitimately takes minutes is many short requests.
+	APITimeout time.Duration
 }
 
 // LoadConfig reads provider configuration from the environment.
-// CLUSTER_NAME is required.
+// CLUSTER_NAME is required; HCLOUD_API_TIMEOUT is optional.
 func LoadConfig() (*Config, error) {
 	name := strings.TrimSpace(os.Getenv("CLUSTER_NAME"))
 	if name == "" {
@@ -26,5 +47,34 @@ func LoadConfig() (*Config, error) {
 	if !clusterNameRE.MatchString(name) {
 		return nil, fmt.Errorf("CLUSTER_NAME %q is not a valid Hetzner label value (must match [a-zA-Z0-9._-], max 63 chars)", name)
 	}
-	return &Config{ClusterName: name}, nil
+	timeout, err := loadAPITimeout()
+	if err != nil {
+		return nil, err
+	}
+	return &Config{ClusterName: name, APITimeout: timeout}, nil
+}
+
+// loadAPITimeout reads HCLOUD_API_TIMEOUT as a Go duration (e.g. "45s", "1m"),
+// falling back to defaultAPITimeout when unset.
+//
+// An unparseable or out-of-range value is an error rather than a silent fallback:
+// falling back would leave the operator running with a timeout the operator who
+// set it does not believe is in effect, and this is exactly the setting someone
+// reaches for when the API is already misbehaving.
+func loadAPITimeout() (time.Duration, error) {
+	raw := strings.TrimSpace(os.Getenv("HCLOUD_API_TIMEOUT"))
+	if raw == "" {
+		return defaultAPITimeout, nil
+	}
+	d, err := time.ParseDuration(raw)
+	if err != nil {
+		return 0, fmt.Errorf("HCLOUD_API_TIMEOUT %q is not a valid duration (e.g. \"30s\", \"1m\"): %w", raw, err)
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("HCLOUD_API_TIMEOUT %q must be positive; an unbounded client is what this setting exists to prevent", raw)
+	}
+	if d > maxAPITimeout {
+		return 0, fmt.Errorf("HCLOUD_API_TIMEOUT %q exceeds the %s maximum", raw, maxAPITimeout)
+	}
+	return d, nil
 }

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -2,16 +2,74 @@ package operator
 
 import (
 	"fmt"
+	"net"
+	"net/http"
 	"os"
+	"time"
 
 	"github.com/hetznercloud/hcloud-go/v2/hcloud"
 )
 
-// NewHCloudClient creates a new Hetzner Cloud API client using the HCLOUD_TOKEN environment variable.
-func NewHCloudClient() (*hcloud.Client, error) {
+// newHTTPClient returns the HTTP client the hcloud SDK is driven with.
+//
+// hcloud.NewClient defaults to a bare &http.Client{}, which has no Timeout and
+// therefore no upper bound on a single request. A blackholed connection to
+// api.hetzner.cloud (dropped SYN/ACK, a middlebox that accepts and never
+// answers, a TLS handshake that stalls) parks the calling goroutine forever.
+// Every call site here is a controller-runtime worker, and controller-runtime
+// imposes no per-reconcile deadline, so a hung request permanently consumes a
+// worker rather than failing and requeueing. Enough of them and the operator
+// stops reconciling entirely while still reporting healthy.
+//
+// The timeout is per REQUEST, not per operation, which is what makes it safe to
+// set aggressively: the SDK's action waiter polls /actions in a loop of separate
+// requests, so a server create that legitimately takes two minutes is a long
+// sequence of short requests, not one long one.
+//
+// A timeout also turns a hang into a retryable error rather than a silent stall:
+// http.Client surfaces it as a net.Error with Timeout() == true, which the SDK's
+// retry policy (5 attempts, exponential backoff capped at a minute) already
+// treats as retryable, and which it abandons as soon as the caller's context is
+// done.
+//
+// The transport bounds the phases individually as well. Client.Timeout alone
+// covers the whole request, so without these a stalled TLS handshake is
+// indistinguishable from a slow response and burns the entire budget before
+// anything is retried.
+func newHTTPClient(timeout time.Duration) *http.Client {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.DialContext = (&net.Dialer{
+		Timeout:   10 * time.Second,
+		KeepAlive: 30 * time.Second,
+	}).DialContext
+	transport.TLSHandshakeTimeout = 10 * time.Second
+	transport.ResponseHeaderTimeout = timeout
+	// The operator talks to exactly one host, and the SDK's action waiter polls it
+	// twice a second per in-flight create. The default of 2 idle connections per
+	// host makes concurrent launches tear down and redial TLS constantly.
+	transport.MaxIdleConnsPerHost = 20
+	return &http.Client{Timeout: timeout, Transport: transport}
+}
+
+// hcloudOptions returns the SDK options used in production. Split out from
+// NewHCloudClient so tests can point the same configuration at a test server.
+func hcloudOptions(token string, timeout time.Duration) []hcloud.ClientOption {
+	return []hcloud.ClientOption{
+		hcloud.WithToken(token),
+		hcloud.WithHTTPClient(newHTTPClient(timeout)),
+		hcloud.WithApplication("karpenter-provider-hetzner", ""),
+	}
+}
+
+// NewHCloudClient creates a new Hetzner Cloud API client using the HCLOUD_TOKEN
+// environment variable and the API timeout from cfg.
+func NewHCloudClient(cfg *Config) (*hcloud.Client, error) {
+	if cfg == nil {
+		return nil, fmt.Errorf("config is required")
+	}
 	token := os.Getenv("HCLOUD_TOKEN")
 	if token == "" {
 		return nil, fmt.Errorf("HCLOUD_TOKEN environment variable is required")
 	}
-	return hcloud.NewClient(hcloud.WithToken(token)), nil
+	return hcloud.NewClient(hcloudOptions(token, cfg.APITimeout)...), nil
 }

--- a/pkg/operator/operator_test.go
+++ b/pkg/operator/operator_test.go
@@ -1,0 +1,144 @@
+package operator
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/hetznercloud/hcloud-go/v2/hcloud"
+)
+
+// hangingServer returns a test server that accepts the connection and never
+// answers, which is the shape of the failure a timeout has to catch: a healthy
+// TCP handshake followed by silence. It is not a dropped packet or a refused
+// connection, both of which fail fast on their own.
+func hangingServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	released := make(chan struct{})
+	t.Cleanup(func() { close(released) })
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case <-released:
+		case <-r.Context().Done():
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// TestHCloudClient_TimesOutOnHangingAPI is the regression for the unbounded
+// client. hcloud.NewClient defaults to a bare &http.Client{}, so before this the
+// call below never returned and the controller-runtime worker that made it was
+// consumed for the life of the process.
+//
+// The context deadline is deliberately much longer than the request timeout: it
+// is the test's backstop, not the thing under test. If the request timeout is
+// what fires, the call returns in roughly the request timeout; if the client is
+// unbounded again, only the context ends it and the elapsed time gives that away.
+func TestHCloudClient_TimesOutOnHangingAPI(t *testing.T) {
+	srv := hangingServer(t)
+
+	client := hcloud.NewClient(append(
+		hcloudOptions("test-token", 200*time.Millisecond),
+		hcloud.WithEndpoint(srv.URL),
+		// One attempt: the production retry policy correctly treats a timeout as
+		// retryable, and its backoff would dominate the test without testing
+		// anything this test is about.
+		hcloud.WithRetryOpts(hcloud.RetryOpts{MaxRetries: 0}),
+	)...)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	start := time.Now()
+	_, err := client.ServerType.All(ctx)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected an error from a hanging API, got nil")
+	}
+	if ctx.Err() != nil {
+		t.Fatalf("the context deadline ended the call after %s, so the HTTP client is still unbounded", elapsed)
+	}
+	if elapsed > 5*time.Second {
+		t.Errorf("call took %s with a 200ms request timeout; the timeout is not bounding the request", elapsed)
+	}
+}
+
+// The transport has to bound the request phases individually, not just the
+// request as a whole: Client.Timeout alone cannot distinguish a stalled TLS
+// handshake from a slow response, so a stall burns the entire budget before the
+// SDK retries anything.
+func TestNewHTTPClient_BoundsEveryPhase(t *testing.T) {
+	c := newHTTPClient(defaultAPITimeout)
+
+	if c.Timeout != defaultAPITimeout {
+		t.Errorf("Timeout = %s, want %s", c.Timeout, defaultAPITimeout)
+	}
+	tr, ok := c.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("Transport is %T, want *http.Transport", c.Transport)
+	}
+	if tr.TLSHandshakeTimeout <= 0 {
+		t.Error("TLSHandshakeTimeout is unset, so a stalled handshake is bounded only by the whole-request timeout")
+	}
+	if tr.ResponseHeaderTimeout <= 0 {
+		t.Error("ResponseHeaderTimeout is unset, so a server that accepts and never answers is bounded only by the whole-request timeout")
+	}
+	// Cloning http.DefaultTransport rather than building a bare &http.Transport{}
+	// is what keeps proxy support and HTTP/2 working; both are silently lost by a
+	// zero-value transport, and a cluster behind an egress proxy would then fail
+	// to reach the API at all.
+	if tr.Proxy == nil {
+		t.Error("Proxy is nil: a bare transport ignores HTTPS_PROXY, which breaks clusters with egress proxies")
+	}
+}
+
+func TestLoadConfig_APITimeoutDefaultsWhenUnset(t *testing.T) {
+	t.Setenv("CLUSTER_NAME", "paperclip-prod")
+	t.Setenv("HCLOUD_API_TIMEOUT", "")
+
+	cfg, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.APITimeout != defaultAPITimeout {
+		t.Errorf("APITimeout = %s, want %s", cfg.APITimeout, defaultAPITimeout)
+	}
+}
+
+func TestLoadConfig_APITimeoutFromEnv(t *testing.T) {
+	t.Setenv("CLUSTER_NAME", "paperclip-prod")
+	t.Setenv("HCLOUD_API_TIMEOUT", "45s")
+
+	cfg, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.APITimeout != 45*time.Second {
+		t.Errorf("APITimeout = %s, want 45s", cfg.APITimeout)
+	}
+}
+
+// A bad value fails startup rather than falling back. Falling back would leave
+// the operator running with a timeout its operator does not believe is in
+// effect, and this is the setting someone reaches for when the API is already
+// misbehaving.
+func TestLoadConfig_RejectsBadAPITimeout(t *testing.T) {
+	for _, bad := range []string{"soon", "30", "0s", "-1s", "10m"} {
+		t.Setenv("CLUSTER_NAME", "paperclip-prod")
+		t.Setenv("HCLOUD_API_TIMEOUT", bad)
+		if _, err := LoadConfig(); err == nil {
+			t.Errorf("expected an error for HCLOUD_API_TIMEOUT %q", bad)
+		}
+	}
+}
+
+func TestNewHCloudClient_RequiresToken(t *testing.T) {
+	t.Setenv("HCLOUD_TOKEN", "")
+	if _, err := NewHCloudClient(&Config{ClusterName: "c", APITimeout: defaultAPITimeout}); err == nil {
+		t.Fatal("expected an error when HCLOUD_TOKEN is unset")
+	}
+}


### PR DESCRIPTION
## Summary

Closes #71 (the HTTP-client half; see Notes for the context-deadline half).

`hcloud.NewClient` defaults to a bare `&http.Client{}` — [`client.go:277`](https://github.com/hetznercloud/hcloud-go/blob/v2.47.0/hcloud/client.go#L277) — which has no `Timeout` and therefore no upper bound on a single request. A connection that is *accepted and never answered* (a blackholed route to `api.hetzner.cloud`, a middlebox that swallows the response, a TLS handshake that stalls) parked the calling goroutine forever.

That matters more here than in a CLI. Every call site is a controller-runtime worker, and controller-runtime imposes no per-reconcile deadline, so a hung request permanently consumed a worker rather than failing and requeueing. Enough of them and the operator stops reconciling entirely while still serving `/healthz` — the failure is invisible from the outside.

The timeout is per **request**, not per operation, which is what makes 30s safe. The SDK's action waiter polls `/actions` on a 500ms constant backoff ([`action_waiter.go:47`](https://github.com/hetznercloud/hcloud-go/blob/v2.47.0/hcloud/action_waiter.go#L47)), so a server create that legitimately takes two minutes is a long sequence of short requests, not one long one.

It also converts a hang into something the SDK already knows how to handle: `http.Client` surfaces a timeout as a `net.Error` with `Timeout() == true`, which `retryPolicy` ([`client_handler_retry.go:80`](https://github.com/hetznercloud/hcloud-go/blob/v2.47.0/hcloud/client_handler_retry.go#L80)) treats as retryable, and which it abandons as soon as the caller's context is done.

## Changes

- `pkg/operator/operator.go`: the SDK is constructed with an explicit `http.Client` — `Timeout`, plus `DialContext`, `TLSHandshakeTimeout` and `ResponseHeaderTimeout` on the transport. `Client.Timeout` alone covers the whole request, so without the per-phase bounds a stalled handshake is indistinguishable from a slow response and burns the entire budget before anything is retried.
- The transport is **cloned from `http.DefaultTransport`** rather than built fresh: a zero-value `&http.Transport{}` silently loses proxy support and HTTP/2, which would break any cluster behind an egress proxy. There is a test for it, because it is the kind of thing a later "simplification" quietly reverts.
- `MaxIdleConnsPerHost: 20`. The operator talks to exactly one host and the action waiter polls it twice a second per in-flight create; the default of 2 makes concurrent launches redial TLS constantly.
- `HCLOUD_API_TIMEOUT` (chart: `hcloud.apiTimeout`, default `30s`, max `5m`) makes it tunable. An unparseable, non-positive or over-max value **fails startup** rather than falling back — falling back would leave the operator running with a timeout its operator does not believe is in effect, and this is the setting someone reaches for when the API is already misbehaving.
- `cmd/controller/main.go`: config is now loaded before the client, since the timeout has to be applied to the `http.Client` the SDK is constructed with and cannot be set afterwards.

## Verification

- [x] `make test` passes (`go test -race -count=1 ./...`, all 9 packages)
- [x] `make generate-verify` passes
- [x] `go vet ./...` clean, `gofmt -l .` empty
- [x] `helm lint` + `helm template` render the new env var
- [x] Added/updated tests for the change

The regression test hangs a `httptest` server and asserts the call returns on the *request* timeout rather than on the test's own 20s context backstop. Mutation-tested — dropping the `WithHTTPClient` option produces exactly:

```
--- FAIL: TestHCloudClient_TimesOutOnHangingAPI (20.00s)
    operator_test.go:63: the context deadline ended the call after 20.001412333s,
                         so the HTTP client is still unbounded
```

## Notes

This closes the HTTP half of #71. The **context-deadline** half is deliberately not in this PR: picking a per-reconcile budget is a real design question (`Create` legitimately blocks for the whole action wait, while the nodeclass controller's reconcile is a handful of bounded GETs), and a wrong budget there cancels healthy provisioning. A per-request bound is the part that is unambiguously correct, and it removes the unbounded-hang failure mode on its own. I'll leave #71 open with a note scoping the remainder.

No behaviour change for a healthy API: Hetzner answers well under a second, and nothing in the SDK holds a single request open by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014t3bi2beVNVVHAxK36dmXm