### PR TITLE
ci: scan pull requests with the latest toolchain, not the go.mod pin

### DIFF
--- a/.github/workflows/security.yaml
+++ b/.github/workflows/security.yaml
@@ -11,7 +11,41 @@ permissions:
   contents: read
 
 jobs:
+  # Two scans, because "is this vulnerable?" has two different answers depending
+  # on who is asking.
+  #
+  # On a pull request the question is whether the CHANGE introduces a vulnerable
+  # dependency. Scanning with the go.mod toolchain answers a different question
+  # badly: setup-go installs exactly the `go` directive, so any branch cut before
+  # the last Go patch bump fails on stdlib advisories that are a property of its
+  # base, not of its diff. Every open contributor PR (#53, #54, #55, #56) failed
+  # this way -- five GO-2026-* stdlib findings, all "Fixed in: go1.26.6", on
+  # branches based on 1.26.5 -- for a bump they had no way to make. Scanning a PR
+  # with the latest stable toolchain removes that noise entirely: a stdlib finding
+  # then means the newest Go is affected, which is genuinely worth a red X.
+  #
+  # On main and on the weekly schedule the question is whether what we SHIP is
+  # vulnerable, and the answer must be pinned to the toolchain we ship with. That
+  # scan is what turned five stdlib advisories into the 1.26.6 bump in #57, so it
+  # keeps the go.mod pin and keeps failing the build.
   govulncheck:
+    name: govulncheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        with:
+          # A PR is scanned against the newest toolchain so stdlib advisories
+          # already fixed upstream cannot fail a contributor's branch.
+          go-version: stable
+      - run: go run golang.org/x/vuln/cmd/govulncheck@latest ./...
+
+  # Pinned to the shipped toolchain. Runs on main and on the weekly schedule --
+  # not on pull requests, where a stale base is the contributor's problem to
+  # inherit rather than to fix.
+  govulncheck-shipped:
+    name: govulncheck (shipped toolchain)
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
## Summary

Our own CI is failing every open contributor PR for something none of them did.

`setup-go` with `go-version-file: go.mod` installs **exactly** the `go` directive. So `govulncheck` on a pull request scans the stdlib of whatever toolchain the branch's *base* declared — and any branch cut before the last Go patch bump fails on advisories that are a property of its base, not of its diff.

That is what is happening right now on #53, #54, #55 and #56. All four are red on `govulncheck` and green on every required check (`test`, `lint`, `generate`, `controllers`). All four report the same five findings:

```
go version go1.26.5 linux/amd64

Vulnerability #1: GO-2026-6218   Found in: net/url@go1.26.5        Fixed in: net/url@go1.26.6
Vulnerability #2: GO-2026-6090   Found in: crypto/tls@go1.26.5     Fixed in: crypto/tls@go1.26.6
Vulnerability #3: GO-2026-6089   Found in: net/http@go1.26.5       Fixed in: net/http@go1.26.6
Vulnerability #4: GO-2026-5972   Found in: encoding/asn1@go1.26.5  Fixed in: encoding/asn1@go1.26.6
Vulnerability #5: GO-2026-5026   Found in: net/http@go1.26.5       Fixed in: net/http@go1.26.6
```

Every one is stdlib, and every one is fixed in 1.26.6 — which #57 landed on `main` **the day after** those PRs were opened. Their code is clean. They were shown a red security check for a toolchain bump they had no way to make, on a check whose failure looks like it is about their diff.

## Changes

Split the job in two, because "is this vulnerable?" has two different answers depending on who is asking.

- **`govulncheck`** (pull requests + main + schedule) now uses `go-version: stable`. On a PR the question is whether the *change* introduces a vulnerable dependency, and the newest toolchain answers that without base-branch noise. A stdlib finding under `stable` means the newest Go is affected — genuinely worth a red X.
- **`govulncheck (shipped toolchain)`** (main + schedule, `if: github.event_name != 'pull_request'`) keeps `go-version-file: go.mod`. On `main` the question is whether *what we ship* is vulnerable, and that has to stay pinned to the toolchain we ship with. This is the scan that turned those same five advisories into the 1.26.6 bump in #57, so it keeps failing the build.

## Verification

- [x] `make test` passes (unchanged — this PR touches only `.github/workflows/security.yaml`)
- [x] `make lint` / `make generate-verify` pass (unchanged)
- [ ] Added/updated tests — n/a, CI configuration

The real verification is this PR's own checks plus the next push on the contributor branches: both jobs must appear here, and only the `stable` one may appear on a PR.

## Notes

Neither job is in the required set (`test`, `lint`, `generate`, `controllers`), so nothing about branch protection changes. What changes is that a red security check on a PR now means something.

The one thing this gives up is that a PR no longer notices a stale shipped toolchain. That was never a PR's job — the `main` push and the Monday schedule both still run the pinned scan, and dependabot's docker updates (#75) keep the Dockerfile base moving independently.

Contributors on #53/#54/#55/#56: no action needed for this; you will still want to rebase for the other reasons noted in your reviews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014t3bi2beVNVVHAxK36dmXm